### PR TITLE
Fix a typo in nifcloud_ssl_certificate doc

### DIFF
--- a/docs/resources/ssl_certificate.md
+++ b/docs/resources/ssl_certificate.md
@@ -5,7 +5,7 @@ description: |-
   Provides a SSL certificate resource.
 ---
 
-# nifcloud_security_group
+# nifcloud_ssl_certificate
 
 Provides a SSL certificate resource.
 


### PR DESCRIPTION
# Summary

- Fix a typo in `nifcloud_ssl_certificate` resource's doc.