### PR TITLE
Fix/ssl certificate without ca

### DIFF
--- a/nifcloud/resources/sslcertificate/flattener.go
+++ b/nifcloud/resources/sslcertificate/flattener.go
@@ -61,13 +61,12 @@ func flatten(d *schema.ResourceData, res *describeResponses) error {
 		return err
 	}
 
-	if res.downloadSSLCertificateResponseForCA == nil {
-		return fmt.Errorf("download certificate authority result is empty")
-	}
-	if err := d.Set(
-		"ca", nifcloud.StringValue(res.downloadSSLCertificateResponseForCA.FileData),
-	); err != nil {
-		return err
+	if res.downloadSSLCertificateResponseForCA != nil {
+		if err := d.Set(
+			"ca", nifcloud.StringValue(res.downloadSSLCertificateResponseForCA.FileData),
+		); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/nifcloud/resources/sslcertificate/flattener_test.go
+++ b/nifcloud/resources/sslcertificate/flattener_test.go
@@ -20,6 +20,15 @@ func TestFlatten(t *testing.T) {
 	})
 	rd.SetId("test_fqdn_id")
 
+	rdWithoutCA := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{
+		"fqdn_id":     "test_fqdn_id",
+		"fqdn":        "test_fqdn",
+		"description": "test_description",
+		"certificate": "test_certificate",
+		"key":         "test_key",
+	})
+	rdWithoutCA.SetId("test_fqdn_id")
+
 	wantNotFoundRd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{})
 
 	type args struct {
@@ -65,6 +74,36 @@ func TestFlatten(t *testing.T) {
 				},
 			},
 			want: rd,
+		},
+		{
+			name: "flattens the response without ca",
+			args: args{
+				d: rdWithoutCA,
+				res: &describeResponses{
+					describeSSLCertificatesResponse: &computing.DescribeSslCertificatesResponse{
+						DescribeSslCertificatesOutput: &computing.DescribeSslCertificatesOutput{
+							CertsSet: []computing.CertsSet{
+								{
+									FqdnId:      nifcloud.String("test_fqdn_id"),
+									Fqdn:        nifcloud.String("test_fqdn"),
+									Description: nifcloud.String("test_description"),
+								},
+							},
+						},
+					},
+					downloadSSLCertificateResponseForCert: &computing.DownloadSslCertificateResponse{
+						DownloadSslCertificateOutput: &computing.DownloadSslCertificateOutput{
+							FileData: nifcloud.String("test_certificate"),
+						},
+					},
+					downloadSSLCertificateResponseForKey: &computing.DownloadSslCertificateResponse{
+						DownloadSslCertificateOutput: &computing.DownloadSslCertificateOutput{
+							FileData: nifcloud.String("test_key"),
+						},
+					},
+				},
+			},
+			want: rdWithoutCA,
 		},
 		{
 			name: "flattens the response even when the resource has been removed externally",

--- a/nifcloud/resources/sslcertificate/read.go
+++ b/nifcloud/resources/sslcertificate/read.go
@@ -48,15 +48,17 @@ func read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Di
 		return nil
 	})
 
-	eg.Go(func() error {
-		var err error
-		req := svc.DownloadSslCertificateRequest(expandDownloadSSLCertificateInputForCA(d))
-		res.downloadSSLCertificateResponseForCA, err = req.Send(ctx)
-		if err != nil {
-			return checkNotFoundError(err)
-		}
-		return nil
-	})
+	if _, ok := d.GetOk("ca"); ok {
+		eg.Go(func() error {
+			var err error
+			req := svc.DownloadSslCertificateRequest(expandDownloadSSLCertificateInputForCA(d))
+			res.downloadSSLCertificateResponseForCA, err = req.Send(ctx)
+			if err != nil {
+				return checkNotFoundError(err)
+			}
+			return nil
+		})
+	}
 
 	if err := eg.Wait(); err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
## Description

- Fixed a bug about cannot apply `nifcloud_ssl_certificate` resource without ca.

## How Has This Been Tested?

- [ ]  Buld with `make install` command, and Apply example.

```:console
$ make install
$ cd examples/ssl_certificate
$ cat << EOF > main.tf
terraform {
  required_providers {
    nifcloud = {
      source = "nifcloud/nifcloud"
    }
  }
}

provider "nifcloud" {
  region = "jp-east-1"
}

resource "nifcloud_ssl_certificate" "example" {
  certificate = file("\${path.module}/certs/certificate.pem")
  key         = file("\${path.module}/certs/private_key.pem")
  description = "memo"
}
EOF
$ terraform init -get-plugins=false
$ terraform plan
$ terraform apply
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation