### PR TITLE
ci: Fix to execute acc only master and release branch

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+      - 'release/*'
 
 jobs:
   # Acceptance tests run.


### PR DESCRIPTION
## Description

- Fix to execute acc test only master and release branch

## How Has This Been Tested?

- [ ]  Acc test not running on pr.

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation