### PR TITLE
Fixed a bug that load balancer creatation cause an error in multi account

### DIFF
--- a/docs/resources/load_balancer.md
+++ b/docs/resources/load_balancer.md
@@ -1,13 +1,13 @@
 ---
 page_title: "NIFCLOUD: nifcloud_load_balancer"
-subcategory: "Computing"
+subcategory: "Network"
 description: |-
-  Provides a load balancer resource.
+  Provides a load_balancer resource.
 ---
 
-## nifcloud_load_balancer
+# nifcloud_load_balancer
 
-Provides a load balancer resource.
+Provides a load_balancer resource.
 
 ## Example Usage
 
@@ -25,16 +25,18 @@ provider "nifcloud" {
 }
 
 resource "nifcloud_load_balancer" "l4lb" {
-  accounting_type = "1"
-  load_balancer_name = "nl4lb"
-  load_balancer_port = 80
+  load_balancer_name = "l4lb"
   instance_port = 80
+  load_balancer_port = 80
+  accounting_type = "1"
 }
+
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
+
 
 * `accounting_type` - (Optional) Accounting type. (1: monthly, 2: pay per use).
 * `balancing_type` - (Optional) Balancing type. (1: Round-Robin, 2: Least-Connection).
@@ -43,20 +45,29 @@ The following arguments are supported:
 * `health_check_interval` - (Optional) The interval between health checks.
 * `health_check_target` - (Optional) The target of the health check. Valid pattern is ${PROTOCOL}:${PORT} or ICMP.
 * `healthy_threshold` - (Optional) The number of checks before the instance is declared healthy.
-* `instances` - (Optional) A list of instance names to place in the multi load balancer pool.
 * `instance_port` - (Required) The port on the instance to route to.
-* `ip_version` - (Optional) The IP version. (v4 or v6).
-* `load_balancer_name` - (Required) The load balancer name.
-* `network_volume` - (Optional) The network volume.
+* `instances` - (Optional) A list of instance names to place in the load balancer pool.
+* `ip_version` - (Optional) The load balancer ip version(v4 or v6).
+* `load_balancer_name` - (Required) The name for the load_balancer.
+* `load_balancer_port` - (Required) The port to listen on for the load balancer.
+* `network_volume` - (Optional) The load balancer max network volume.
+* `policy_type` - (Optional) policy type (standard or ats).
 * `session_stickiness_policy_enable` - (Optional) The flag of session stickiness policy.
 * `session_stickiness_policy_expiration_period` - (Optional) The session stickiness policy expiration period.
 * `sorry_page_enable` - (Optional) The flag of sorry page.
-* `sorry_page_status_code` - (Optional)  The HTTP status code for sorry page.
+* `sorry_page_status_code` - (Optional) The HTTP status code for sorry page.
 * `ssl_certificate_id` - (Optional) The id of the SSL certificate you have uploaded to NIFCLOUD.
 * `ssl_policy_id` - (Optional) The id of the SSL policy.
 * `ssl_policy_name` - (Optional) The name of the SSL policy.
-* `policy_type` - (Optional) The policy type. (standard or ats).
 * `unhealthy_threshold` - (Optional) The number of checks before the instance is declared unhealthy.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+
+* `dns_name` - dns_name
+
 
 ## Import
 

--- a/docs/resources/load_balancer_listener.md
+++ b/docs/resources/load_balancer_listener.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 
 * `balancing_type` - (Optional) Balancing type. (1: Round-Robin, 2: Least-Connection).
-* `filter` - (Optional) A list of IP address filter for load balancer
+* `filter` - (Optional) A list of IP address filter for load balancer.
 * `filter_type` - (Optional) The filter_type of filter (1: Allow, 2: Deny).
 * `health_check_interval` - (Optional) The interval between health checks.
 * `health_check_target` - (Optional) The target of the health check. Valid pattern is ${PROTOCOL}:${PORT} or ICMP.

--- a/docs/resources/load_balancer_listener.md
+++ b/docs/resources/load_balancer_listener.md
@@ -1,13 +1,13 @@
 ---
 page_title: "NIFCLOUD: nifcloud_load_balancer_listener"
-subcategory: "Computing"
+subcategory: "Network"
 description: |-
-  Provides a load balancer listener resource.
+  Provides a load_balancer_listener resource.
 ---
 
-## nifcloud_load_balancer_listener
+# nifcloud_load_balancer_listener
 
-Provides a load balancer listener resource.
+Provides a load_balancer_listener resource.
 
 ## Example Usage
 
@@ -19,50 +19,62 @@ terraform {
     }
   }
 }
+
 provider "nifcloud" {
   region = "jp-east-1"
 }
+
 resource "nifcloud_load_balancer" "basic" {
-  load_balancer_name = "l4lb"
+  load_balancer_name = "l4lbl"
   instance_port = 80
   load_balancer_port = 80
   accounting_type = "1"
 }
+
 resource "nifcloud_load_balancer_listener" "ssh" {
   load_balancer_name = nifcloud_load_balancer.basic.load_balancer_name
   instance_port = 22
   load_balancer_port = 22
 }
+
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
+
 * `balancing_type` - (Optional) Balancing type. (1: Round-Robin, 2: Least-Connection).
-* `filter` - (Optional) A list of IP address filter for load balancer.
+* `filter` - (Optional) A list of IP address filter for load balancer
 * `filter_type` - (Optional) The filter_type of filter (1: Allow, 2: Deny).
 * `health_check_interval` - (Optional) The interval between health checks.
 * `health_check_target` - (Optional) The target of the health check. Valid pattern is ${PROTOCOL}:${PORT} or ICMP.
 * `healthy_threshold` - (Optional) The number of checks before the instance is declared healthy.
-* `instances` - (Optional) A list of instance names to place in the multi load balancer pool.
 * `instance_port` - (Required) The port on the instance to route to.
-* `ip_version` - (Optional) The IP version. (v4 or v6).
-* `load_balancer_name` - (Required) The load balancer name.
+* `instances` - (Optional) A list of instance names to place in the load balancer pool.
+* `ip_version` - (Optional) The load balancer ip version(v4 or v6).
+* `load_balancer_name` - (Required) The name for the load_balancer.
+* `load_balancer_port` - (Required) The port to listen on for the load balancer.
+* `policy_type` - (Optional) policy type (standard or ats).
 * `session_stickiness_policy_enable` - (Optional) The flag of session stickiness policy.
 * `session_stickiness_policy_expiration_period` - (Optional) The session stickiness policy expiration period.
 * `sorry_page_enable` - (Optional) The flag of sorry page.
-* `sorry_page_status_code` - (Optional)  The HTTP status code for sorry page.
+* `sorry_page_status_code` - (Optional) The HTTP status code for sorry page.
 * `ssl_certificate_id` - (Optional) The id of the SSL certificate you have uploaded to NIFCLOUD.
 * `ssl_policy_id` - (Optional) The id of the SSL policy.
 * `ssl_policy_name` - (Optional) The name of the SSL policy.
-* `policy_type` - (Optional) The policy type. (standard or ats).
 * `unhealthy_threshold` - (Optional) The number of checks before the instance is declared unhealthy.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+
 
 ## Import
 
 nifcloud_load_balancer_listener can be imported using the `parameter corresponding to id`, e.g.
 
 ```
-$ terraform import nifcloud_load_balancer.example foo
+$ terraform import nifcloud_load_balancer_listener.example foo
 ```

--- a/nifcloud/resources/network/loadbalancer/update.go
+++ b/nifcloud/resources/network/loadbalancer/update.go
@@ -19,7 +19,7 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		"instance_port",
 		"load_balancer_port",
 		"load_balancer_name",
-	) {
+	) && !d.IsNewResource() {
 		input := expandUpdateLoadBalancer(d)
 		req := svc.UpdateLoadBalancerRequest(input)
 		_, err := req.Send(ctx)

--- a/nifcloud/resources/network/loadbalancerlistener/update.go
+++ b/nifcloud/resources/network/loadbalancerlistener/update.go
@@ -15,7 +15,7 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		"balancing_type",
 		"instance_port",
 		"load_balancer_port",
-	) {
+	) && !d.IsNewResource() {
 		input := expandUpdateLoadBalancer(d)
 		req := svc.UpdateLoadBalancerRequest(input)
 		_, err := req.Send(ctx)


### PR DESCRIPTION
## Description

- Fix load balancer resource document
- Fixed a bug that load balancer creatation cause an error in multi account

## How Has This Been Tested?

- [ ]  Run `terraform apply` in `examples/loadbalancer`. (use multi account credentials)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation