### PR TITLE
Fix to use latest nifcloud-sdk-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.0
 	github.com/katbyte/terrafmt v0.2.0
-	github.com/nifcloud/nifcloud-sdk-go v1.4.0
+	github.com/nifcloud/nifcloud-sdk-go v1.5.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 )

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nifcloud/nifcloud-sdk-go v1.4.0 h1:zhtbZ5GiPtaKag/MMLtFEc7lqxQByVC3nJW2E7QU43Q=
-github.com/nifcloud/nifcloud-sdk-go v1.4.0/go.mod h1:W4Qs1quyJDiJ5GJ6J+scXUHxy5d4hlrzBZd1oUyyUqo=
+github.com/nifcloud/nifcloud-sdk-go v1.5.0 h1:jS8WScfTp67fe3rIELz5R/VoN/t8pC+q7eFy8oKNMYI=
+github.com/nifcloud/nifcloud-sdk-go v1.5.0/go.mod h1:W4Qs1quyJDiJ5GJ6J+scXUHxy5d4hlrzBZd1oUyyUqo=
 github.com/nishanths/exhaustive v0.0.0-20200708172631-8866003e3856/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0 h1:eMV1t2NQRc3r1k3guWiv/zEeqZZP6kPvpUfy6byfL1g=
 github.com/nishanths/exhaustive v0.0.0-20200811152831-6cf413ae40e0/go.mod h1:wBEpHwM2OdmeNpdCvRPUlkEbBuaFmcK4Wv8Q7FuGW3c=

--- a/nifcloud/resources/computing/instance/expander.go
+++ b/nifcloud/resources/computing/instance/expander.go
@@ -96,24 +96,24 @@ func expandTerminateInstancesInput(d *schema.ResourceData) *computing.TerminateI
 func expandModifyInstanceAttributeInputForAccountingType(d *schema.ResourceData) *computing.ModifyInstanceAttributeInput {
 	return &computing.ModifyInstanceAttributeInput{
 		InstanceId: nifcloud.String(d.Id()),
-		Attribute:  "accountingType",
-		Value:      computing.ValueOfModifyInstanceAttributeRequest(d.Get("accounting_type").(string)),
+		Attribute:  computing.AttributeOfModifyInstanceAttributeRequestAccountingType,
+		Value:      nifcloud.String(d.Get("accounting_type").(string)),
 	}
 }
 
 func expandModifyInstanceAttributeInputForDescription(d *schema.ResourceData) *computing.ModifyInstanceAttributeInput {
 	return &computing.ModifyInstanceAttributeInput{
 		InstanceId: nifcloud.String(d.Id()),
-		Attribute:  "description",
-		Value:      computing.ValueOfModifyInstanceAttributeRequest(d.Get("description").(string)),
+		Attribute:  computing.AttributeOfModifyInstanceAttributeRequestDescription,
+		Value:      nifcloud.String(d.Get("description").(string)),
 	}
 }
 
 func expandModifyInstanceAttributeInputForDisableAPITermination(d *schema.ResourceData) *computing.ModifyInstanceAttributeInput {
 	return &computing.ModifyInstanceAttributeInput{
 		InstanceId: nifcloud.String(d.Id()),
-		Attribute:  "disableApiTermination",
-		Value:      computing.ValueOfModifyInstanceAttributeRequest(strconv.FormatBool(d.Get("disable_api_termination").(bool))),
+		Attribute:  computing.AttributeOfModifyInstanceAttributeRequestDisableApiTermination,
+		Value:      nifcloud.String(strconv.FormatBool(d.Get("disable_api_termination").(bool))),
 	}
 }
 
@@ -122,23 +122,23 @@ func expandModifyInstanceAttributeInputForInstanceID(d *schema.ResourceData) *co
 
 	return &computing.ModifyInstanceAttributeInput{
 		InstanceId: nifcloud.String(before.(string)),
-		Attribute:  "instanceName",
-		Value:      computing.ValueOfModifyInstanceAttributeRequest(after.(string)),
+		Attribute:  computing.AttributeOfModifyInstanceAttributeRequestInstanceName,
+		Value:      nifcloud.String(after.(string)),
 	}
 }
 func expandModifyInstanceAttributeInputForInstanceType(d *schema.ResourceData) *computing.ModifyInstanceAttributeInput {
 	return &computing.ModifyInstanceAttributeInput{
 		InstanceId: nifcloud.String(d.Id()),
-		Attribute:  "instanceType",
-		Value:      computing.ValueOfModifyInstanceAttributeRequest(d.Get("instance_type").(string)),
+		Attribute:  computing.AttributeOfModifyInstanceAttributeRequestInstanceType,
+		Value:      nifcloud.String(d.Get("instance_type").(string)),
 	}
 }
 
 func expandModifyInstanceAttributeInputForSecurityGroup(d *schema.ResourceData) *computing.ModifyInstanceAttributeInput {
 	return &computing.ModifyInstanceAttributeInput{
 		InstanceId: nifcloud.String(d.Id()),
-		Attribute:  "groupId",
-		Value:      computing.ValueOfModifyInstanceAttributeRequest(d.Get("security_group").(string)),
+		Attribute:  computing.AttributeOfModifyInstanceAttributeRequestGroupId,
+		Value:      nifcloud.String(d.Get("security_group").(string)),
 	}
 }
 

--- a/nifcloud/resources/computing/instance/expander_test.go
+++ b/nifcloud/resources/computing/instance/expander_test.go
@@ -215,8 +215,8 @@ func TestExpandModifyInstanceAttributeInputForAccountingType(t *testing.T) {
 			args: rd,
 			want: &computing.ModifyInstanceAttributeInput{
 				InstanceId: nifcloud.String("test_instance_id"),
-				Attribute:  "accountingType",
-				Value:      "test_accounting_type",
+				Attribute:  computing.AttributeOfModifyInstanceAttributeRequestAccountingType,
+				Value:      nifcloud.String("test_accounting_type"),
 			},
 		},
 	}
@@ -246,8 +246,8 @@ func TestExpandModifyInstanceAttributeInputForDescription(t *testing.T) {
 			args: rd,
 			want: &computing.ModifyInstanceAttributeInput{
 				InstanceId: nifcloud.String("test_instance_id"),
-				Attribute:  "description",
-				Value:      "test_description",
+				Attribute:  computing.AttributeOfModifyInstanceAttributeRequestDescription,
+				Value:      nifcloud.String("test_description"),
 			},
 		},
 	}
@@ -277,8 +277,8 @@ func TestExpandModifyInstanceAttributeInputForDisableAPITermination(t *testing.T
 			args: rd,
 			want: &computing.ModifyInstanceAttributeInput{
 				InstanceId: nifcloud.String("test_instance_id"),
-				Attribute:  "disableApiTermination",
-				Value:      computing.ValueOfModifyInstanceAttributeRequest("false"),
+				Attribute:  computing.AttributeOfModifyInstanceAttributeRequestDisableApiTermination,
+				Value:      nifcloud.String("false"),
 			},
 		},
 	}
@@ -309,8 +309,8 @@ func TestExpandModifyInstanceAttributeInputForInstanceID(t *testing.T) {
 			args: dn,
 			want: &computing.ModifyInstanceAttributeInput{
 				InstanceId: nifcloud.String("test_instance_id"),
-				Attribute:  "instanceName",
-				Value:      computing.ValueOfModifyInstanceAttributeRequest("test_instance_id"),
+				Attribute:  computing.AttributeOfModifyInstanceAttributeRequestInstanceName,
+				Value:      nifcloud.String("test_instance_id"),
 			},
 		},
 	}
@@ -340,8 +340,8 @@ func TestExpandModifyInstanceAttributeInputForInstanceType(t *testing.T) {
 			args: rd,
 			want: &computing.ModifyInstanceAttributeInput{
 				InstanceId: nifcloud.String("test_instance_id"),
-				Attribute:  "instanceType",
-				Value:      computing.ValueOfModifyInstanceAttributeRequest("test_instance_type"),
+				Attribute:  computing.AttributeOfModifyInstanceAttributeRequestInstanceType,
+				Value:      nifcloud.String("test_instance_type"),
 			},
 		},
 	}
@@ -371,8 +371,8 @@ func TestExpandModifyInstanceAttributeInputForSecurityGroup(t *testing.T) {
 			args: rd,
 			want: &computing.ModifyInstanceAttributeInput{
 				InstanceId: nifcloud.String("test_instance_id"),
-				Attribute:  "groupId",
-				Value:      computing.ValueOfModifyInstanceAttributeRequest("test_security_group"),
+				Attribute:  computing.AttributeOfModifyInstanceAttributeRequestGroupId,
+				Value:      nifcloud.String("test_security_group"),
 			},
 		},
 	}

--- a/nifcloud/resources/computing/instance/update.go
+++ b/nifcloud/resources/computing/instance/update.go
@@ -214,10 +214,10 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 
 			req := svc.ModifyInstanceAttributeRequest(input)
 
-			mutexKV.Lock(string(input.Value))
-			defer mutexKV.Unlock(string(input.Value))
+			mutexKV.Lock(nifcloud.StringValue(input.Value))
+			defer mutexKV.Unlock(nifcloud.StringValue(input.Value))
 
-			err := svc.WaitUntilSecurityGroupApplied(ctx, &computing.DescribeSecurityGroupsInput{GroupName: []string{string(input.Value)}})
+			err := svc.WaitUntilSecurityGroupApplied(ctx, &computing.DescribeSecurityGroupsInput{GroupName: []string{nifcloud.StringValue(input.Value)}})
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("failed wait until securityGroup applied: %s", err))
 			}

--- a/nifcloud/resources/network/router/expander.go
+++ b/nifcloud/resources/network/router/expander.go
@@ -75,7 +75,7 @@ func expandNiftyModifyRouterAttributeInputForRouterName(d *schema.ResourceData) 
 	return &computing.NiftyModifyRouterAttributeInput{
 		RouterId:  nifcloud.String(d.Id()),
 		Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestRouterName,
-		Value:     computing.ValueOfNiftyModifyRouterAttributeRequest(d.Get("name").(string)),
+		Value:     nifcloud.String(d.Get("name").(string)),
 	}
 }
 
@@ -83,7 +83,7 @@ func expandNiftyModifyRouterAttributeInputForAccountingType(d *schema.ResourceDa
 	return &computing.NiftyModifyRouterAttributeInput{
 		RouterId:  nifcloud.String(d.Id()),
 		Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestAccountingType,
-		Value:     computing.ValueOfNiftyModifyRouterAttributeRequest(d.Get("accounting_type").(string)),
+		Value:     nifcloud.String(d.Get("accounting_type").(string)),
 	}
 }
 
@@ -91,7 +91,7 @@ func expandNiftyModifyRouterAttributeInputForDescription(d *schema.ResourceData)
 	return &computing.NiftyModifyRouterAttributeInput{
 		RouterId:  nifcloud.String(d.Id()),
 		Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestDescription,
-		Value:     computing.ValueOfNiftyModifyRouterAttributeRequest(d.Get("description").(string)),
+		Value:     nifcloud.String(d.Get("description").(string)),
 	}
 }
 
@@ -99,7 +99,7 @@ func expandNiftyModifyRouterAttributeInputForType(d *schema.ResourceData) *compu
 	return &computing.NiftyModifyRouterAttributeInput{
 		RouterId:  nifcloud.String(d.Id()),
 		Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestType,
-		Value:     computing.ValueOfNiftyModifyRouterAttributeRequest(d.Get("type").(string)),
+		Value:     nifcloud.String(d.Get("type").(string)),
 	}
 }
 
@@ -107,7 +107,7 @@ func expandNiftyModifyRouterAttributeInputForSecurityGroup(d *schema.ResourceDat
 	return &computing.NiftyModifyRouterAttributeInput{
 		RouterId:  nifcloud.String(d.Id()),
 		Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestGroupId,
-		Value:     computing.ValueOfNiftyModifyRouterAttributeRequest(d.Get("security_group").(string)),
+		Value:     nifcloud.String(d.Get("security_group").(string)),
 	}
 }
 

--- a/nifcloud/resources/network/router/expander_test.go
+++ b/nifcloud/resources/network/router/expander_test.go
@@ -169,7 +169,7 @@ func TestExpandNiftyModifyRouterAttributeInputForRouterName(t *testing.T) {
 			want: &computing.NiftyModifyRouterAttributeInput{
 				RouterId:  nifcloud.String("test_router_id"),
 				Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestRouterName,
-				Value:     computing.ValueOfNiftyModifyRouterAttributeRequest("test_router_name"),
+				Value:     nifcloud.String("test_router_name"),
 			},
 		},
 	}
@@ -199,7 +199,7 @@ func TestExpandNiftyModifyRouterAttributeInputForAccountingType(t *testing.T) {
 			want: &computing.NiftyModifyRouterAttributeInput{
 				RouterId:  nifcloud.String("test_router_id"),
 				Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestAccountingType,
-				Value:     computing.ValueOfNiftyModifyRouterAttributeRequest("test_accounting_type"),
+				Value:     nifcloud.String("test_accounting_type"),
 			},
 		},
 	}
@@ -229,7 +229,7 @@ func TestExpandNiftyModifyRouterAttributeInputForDescription(t *testing.T) {
 			want: &computing.NiftyModifyRouterAttributeInput{
 				RouterId:  nifcloud.String("test_router_id"),
 				Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestDescription,
-				Value:     computing.ValueOfNiftyModifyRouterAttributeRequest("test_description"),
+				Value:     nifcloud.String("test_description"),
 			},
 		},
 	}
@@ -259,7 +259,7 @@ func TestExpandNiftyModifyRouterAttributeInputForType(t *testing.T) {
 			want: &computing.NiftyModifyRouterAttributeInput{
 				RouterId:  nifcloud.String("test_router_id"),
 				Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestType,
-				Value:     computing.ValueOfNiftyModifyRouterAttributeRequest("test_type"),
+				Value:     nifcloud.String("test_type"),
 			},
 		},
 	}
@@ -289,7 +289,7 @@ func TestExpandNiftyModifyRouterAttributeInputForSecurityGroup(t *testing.T) {
 			want: &computing.NiftyModifyRouterAttributeInput{
 				RouterId:  nifcloud.String("test_router_id"),
 				Attribute: computing.AttributeOfNiftyModifyRouterAttributeRequestGroupId,
-				Value:     computing.ValueOfNiftyModifyRouterAttributeRequest("test_security_group"),
+				Value:     nifcloud.String("test_security_group"),
 			},
 		},
 	}

--- a/nifcloud/resources/network/vpngateway/expander.go
+++ b/nifcloud/resources/network/vpngateway/expander.go
@@ -59,7 +59,7 @@ func expandNiftyModifyVpnGatewayAttributeInputForAccountingType(d *schema.Resour
 	return &computing.NiftyModifyVpnGatewayAttributeInput{
 		VpnGatewayId: nifcloud.String(d.Id()),
 		Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayAccountingType,
-		Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest(d.Get("accounting_type").(string)),
+		Value:        nifcloud.String(d.Get("accounting_type").(string)),
 	}
 }
 
@@ -67,7 +67,7 @@ func expandNiftyModifyVpnGatewayAttributeInputForVpnGatewayDescription(d *schema
 	return &computing.NiftyModifyVpnGatewayAttributeInput{
 		VpnGatewayId: nifcloud.String(d.Id()),
 		Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayDescription,
-		Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest(d.Get("description").(string)),
+		Value:        nifcloud.String(d.Get("description").(string)),
 	}
 }
 
@@ -75,7 +75,7 @@ func expandNiftyModifyVpnGatewayAttributeInputForVpnGatewayName(d *schema.Resour
 	return &computing.NiftyModifyVpnGatewayAttributeInput{
 		VpnGatewayId: nifcloud.String(d.Id()),
 		Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayName,
-		Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest(d.Get("name").(string)),
+		Value:        nifcloud.String(d.Get("name").(string)),
 	}
 }
 
@@ -83,7 +83,7 @@ func expandNiftyModifyVpnGatewayAttributeInputForVpnGatewayType(d *schema.Resour
 	return &computing.NiftyModifyVpnGatewayAttributeInput{
 		VpnGatewayId: nifcloud.String(d.Id()),
 		Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayType,
-		Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest(d.Get("type").(string)),
+		Value:        nifcloud.String(d.Get("type").(string)),
 	}
 }
 
@@ -100,7 +100,7 @@ func expandNiftyModifyVpnGatewayAttributeInputForSecurityGroup(d *schema.Resourc
 	return &computing.NiftyModifyVpnGatewayAttributeInput{
 		VpnGatewayId: nifcloud.String(d.Id()),
 		Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestGroupId,
-		Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest(d.Get("security_group").(string)),
+		Value:        nifcloud.String(d.Get("security_group").(string)),
 	}
 }
 

--- a/nifcloud/resources/network/vpngateway/expander_test.go
+++ b/nifcloud/resources/network/vpngateway/expander_test.go
@@ -219,7 +219,7 @@ func TestExpandNiftyModifyVpnGatewayAttributeInputForAccountingType(t *testing.T
 			want: &computing.NiftyModifyVpnGatewayAttributeInput{
 				VpnGatewayId: nifcloud.String("test_vpngateway_id"),
 				Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayAccountingType,
-				Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest("test_accounting_type"),
+				Value:        nifcloud.String("test_accounting_type"),
 			},
 		},
 	}
@@ -249,7 +249,7 @@ func TestExpandNiftyModifyVpnGatewayAttributeInputForVpnGatewayDescription(t *te
 			want: &computing.NiftyModifyVpnGatewayAttributeInput{
 				VpnGatewayId: nifcloud.String("test_vpngateway_id"),
 				Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayDescription,
-				Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest("test_description"),
+				Value:        nifcloud.String("test_description"),
 			},
 		},
 	}
@@ -279,7 +279,7 @@ func TestExpandNiftyModifyVpnGatewayAttributeInputForVpnGatewayName(t *testing.T
 			want: &computing.NiftyModifyVpnGatewayAttributeInput{
 				VpnGatewayId: nifcloud.String("test_vpngateway_id"),
 				Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayName,
-				Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest("test_name"),
+				Value:        nifcloud.String("test_name"),
 			},
 		},
 	}
@@ -309,7 +309,7 @@ func TestExpandNiftyModifyVpnGatewayAttributeInputForVpnGatewayType(t *testing.T
 			want: &computing.NiftyModifyVpnGatewayAttributeInput{
 				VpnGatewayId: nifcloud.String("test_vpngateway_id"),
 				Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestNiftyVpnGatewayType,
-				Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest("test_type"),
+				Value:        nifcloud.String("test_type"),
 			},
 		},
 	}
@@ -370,7 +370,7 @@ func TestExpandNiftyModifyVpnGatewayAttributeInputForSecurityGroup(t *testing.T)
 			want: &computing.NiftyModifyVpnGatewayAttributeInput{
 				VpnGatewayId: nifcloud.String("test_vpngateway_id"),
 				Attribute:    computing.AttributeOfNiftyModifyVpnGatewayAttributeRequestGroupId,
-				Value:        computing.ValueOfNiftyModifyVpnGatewayAttributeRequest("test_security_group"),
+				Value:        nifcloud.String("test_security_group"),
 			},
 		},
 	}


### PR DESCRIPTION
## Description

- Fix to use latest nifcloud-sdk-go (v1.5.0)
    - Fix enum values for `Modify*Attribute` API

## How Has This Been Tested?

- [ ] CI passes

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
