### PR TITLE
resource/nifcloud_instance: Fix buf of flatten network_interface

### DIFF
--- a/nifcloud/resources/computing/instance/flattener.go
+++ b/nifcloud/resources/computing/instance/flattener.go
@@ -75,17 +75,17 @@ func flatten(d *schema.ResourceData, res *computing.DescribeInstancesResponse) e
 			for _, dn := range d.Get("network_interface").(*schema.Set).List() {
 				elm := dn.(map[string]interface{})
 
-				if elm["network_id"] == nifcloud.StringValue(n.NiftyNetworkId) {
+				if elm["network_id"] != nil && n.NiftyNetworkId != nil && elm["network_id"] == nifcloud.StringValue(n.NiftyNetworkId) {
 					findElm = elm
 					break
 				}
 
-				if elm["network_name"] == nifcloud.StringValue(n.NiftyNetworkName) {
+				if elm["network_name"] != nil && n.NiftyNetworkName != nil && elm["network_name"] == nifcloud.StringValue(n.NiftyNetworkName) {
 					findElm = elm
 					break
 				}
 
-				if elm["network_interface_id"] == nifcloud.StringValue(n.NetworkInterfaceId) {
+				if elm["network_interface_id"] != nil && n.NetworkInterfaceId != nil && elm["network_interface_id"] == nifcloud.StringValue(n.NetworkInterfaceId) {
 					findElm = elm
 					break
 				}


### PR DESCRIPTION
## Description

- Fixed bad state when `ip address` of `network interface` is `static`.

## How Has This Been Tested?

- [x]  Buld with `make install` command, and Apply resources, and Run `terraform plan` command.

```:hcl
network_interface {
    network_id = nifcloud_private_lan.basic.id
    ip_address = "static"
 }
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation