### PR TITLE
Fix nifcloud_security_group name

### DIFF
--- a/docs/resources/router.md
+++ b/docs/resources/router.md
@@ -27,7 +27,7 @@ provider "nifcloud" {
 resource "nifcloud_router" "router" {
   name       = "router"
   availability_zone = "east-12"
-  security_group    = nifcloud_security_group.web.group_name
+  security_group    = nifcloud_security_group.router.group_name
   type              = "small"
   accounting_type   = "2"
 


### PR DESCRIPTION
## Description

- Fix nifcloud_security_group name

## How Has This Been Tested?

- [x]  Run after changing the name of `nifcloud_security_group` . 

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation