### PR TITLE
Add dhcp default value for nifcloud_router

### DIFF
--- a/nifcloud/resources/network/router/schema.go
+++ b/nifcloud/resources/network/router/schema.go
@@ -85,6 +85,7 @@ func newSchema() map[string]*schema.Schema {
 						Type:        schema.TypeBool,
 						Description: "The flag to enable or disable DHCP.",
 						Optional:    true,
+						Default:     true,
 					},
 					"dhcp_config_id": {
 						Type:        schema.TypeString,


### PR DESCRIPTION
## Description

After updated terraform 1.0.0, I noticed that when I plan after applying the example router resource (in example/router directory), differences are detected. (see below)

```
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # nifcloud_router.basic has been changed
  ~ resource "nifcloud_router" "basic" {
        id                = "rt-0k87jjuz"
        name              = "example"
        # (6 unchanged attributes hidden)

      + network_interface {
          + dhcp         = false
          + ip_address   = "192.168.1.1"
          + network_name = "example"
        }
      - network_interface {
          - ip_address   = "192.168.1.1" -> null
          - network_name = "example" -> null
        }
    }
```

attribute `dhcp` is the computed attribute, so I added the `Computed` option to `dhcp` schema.

## How Has This Been Tested?

```
make install
cd examples/hatoba_cluster
terraform init -plugin-dir ~/.terraform.d/plugins
terraform plan
terraform apply
terraform plan # confirm that diff is not detected
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation