### PR TITLE
Fix DB security group rule waiter: wait until target rule is revoked

### DIFF
--- a/nifcloud/resources/rdb/dbsecuritygroup/helper.go
+++ b/nifcloud/resources/rdb/dbsecuritygroup/helper.go
@@ -1,0 +1,56 @@
+package dbsecuritygroup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+	"github.com/nifcloud/nifcloud-sdk-go/service/rdb"
+)
+
+func waitUntilDBSecurityGroupRuleRevoked(ctx context.Context, d *schema.ResourceData, svc *rdb.Client, rule map[string]interface{}) error {
+	const maxRetryCount = 20
+	const pollInterval = 10 * time.Second
+
+	retryCount := 0
+	for {
+		if retryCount > maxRetryCount {
+			return fmt.Errorf("max retry count exceeded about waiting db security group rule revoked: rule -> %v", rule)
+		}
+
+		input := expandDescribeDBSecurityGroupsInput(d)
+		req := svc.DescribeDBSecurityGroupsRequest(input)
+		res, err := req.Send(ctx)
+		if err != nil {
+			return err
+		}
+
+		targetExists := false
+		if rule["cidr_ip"] != "" {
+			target := rule["cidr_ip"].(string)
+			for _, ip := range res.DescribeDBSecurityGroupsOutput.DBSecurityGroups[0].IPRanges {
+				if nifcloud.StringValue(ip.CIDRIP) == target && nifcloud.StringValue(ip.Status) == "revoking" {
+					targetExists = true
+					break
+				}
+			}
+		} else {
+			target := rule["security_group_name"].(string)
+			for _, group := range res.DescribeDBSecurityGroupsOutput.DBSecurityGroups[0].EC2SecurityGroups {
+				if nifcloud.StringValue(group.EC2SecurityGroupName) == target && nifcloud.StringValue(group.Status) == "revoking" {
+					targetExists = true
+					break
+				}
+			}
+		}
+
+		if !targetExists {
+			return nil
+		}
+
+		time.Sleep(pollInterval)
+		retryCount++
+	}
+}

--- a/nifcloud/resources/rdb/dbsecuritygroup/schema.go
+++ b/nifcloud/resources/rdb/dbsecuritygroup/schema.go
@@ -43,7 +43,6 @@ func newSchema() map[string]*schema.Schema {
 						Type:        schema.TypeString,
 						Description: "The CIDR IP Address that allow access. Cannot be specified with `security_group_name` .",
 						Optional:    true,
-						ForceNew:    true,
 						ValidateDiagFunc: validator.Any(
 							validator.CIDRNetworkAddress,
 							validator.IPAddress,
@@ -53,7 +52,6 @@ func newSchema() map[string]*schema.Schema {
 						Type:        schema.TypeString,
 						Description: "The security group name that allow access. Cannot be specified with `cidr_ip` .",
 						Optional:    true,
-						ForceNew:    true,
 						ValidateFunc: validation.All(
 							validation.StringLenBetween(1, 15),
 							validation.StringMatch(regexp.MustCompile(`^[0-9a-zA-Z]+$`), ""),

--- a/nifcloud/resources/rdb/dbsecuritygroup/update.go
+++ b/nifcloud/resources/rdb/dbsecuritygroup/update.go
@@ -35,13 +35,7 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 				return diag.FromErr(fmt.Errorf("failed updating db security group to delete rule: %s", err))
 			}
 
-			if rule["cidr_ip"] != "" {
-				err = svc.WaitUntilDBSecurityGroupIPRangesEmptied(ctx, expandDescribeDBSecurityGroupsInput(d))
-			} else if rule["security_group_name"] != "" {
-				err = svc.WaitUntilDBSecurityGroupEC2SecurityGroupsEmptied(ctx, expandDescribeDBSecurityGroupsInput(d))
-			}
-
-			if err != nil {
+			if err := waitUntilDBSecurityGroupRuleRevoked(ctx, d, svc, rule); err != nil {
 				return diag.FromErr(fmt.Errorf("failed wait db security group available: %s", err))
 			}
 		}


### PR DESCRIPTION
## Description

if changing the db security group rule (like below), waiter will keep waiting until it times out.

```
...
  rule {
    cidr_ip = "192.168.0.1/32"
  }
  rule {
    cidr_ip = "192.168.0.2/32"
  }
```
↓
```
...
  rule {
    cidr_ip = "192.168.0.1/32"
  }
```

This behavior caused by waiter condition in https://github.com/nifcloud/terraform-provider-nifcloud/blob/v1.3.2/nifcloud/resources/rdb/dbsecuritygroup/update.go#L38-L42
(waiter wait until security group rule was emptied 😇)

So I added the custom waiter to check the specified rule was revoked.

## How Has This Been Tested?

- [x] create the db security group with 2 cidr ip rules.
- [x] delete a rule from tf file.
- [x] confirm that resource is successfully applied.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation