### PR TITLE
Improve the AD server provisioning script for NAS instance test

### DIFF
--- a/nifcloud/acc/testdata/scripts/provision_ad_server.sh
+++ b/nifcloud/acc/testdata/scripts/provision_ad_server.sh
@@ -2,6 +2,14 @@
 
 set -euo pipefail
 
+function change_apt_repository () {
+  sed -i.bak -e "s%http://[^ ]\+%http://ftp.riken.go.jp/Linux/ubuntu/%g" /etc/apt/sources.list
+}
+
+function disable_auto_update () {
+  echo 'APT::Periodic::Enable "0";' | tee /etc/apt/apt.conf.d/99disable-periodic
+}
+
 function configure_ad_server () {
   HOST_NAME="AD01"
   DOMAIN="TFACC"
@@ -51,4 +59,6 @@ EOF
   systemctl restart samba-ad-dc.service
 }
 
+disable_auto_update
+change_apt_repository
 configure_ad_server


### PR DESCRIPTION
## Description

* Fix startup script for nifcloud_nas_instance (cifs protocol) test
    * Disable the unattended upgrade
        * startup script conflict with unattended upgrade 😇 
    * Change apt repositry to riken because original repository is too slow

## How Has This Been Tested?

- [x] Run the acceptance test.

```
TF_ACC=1 go test ./nifcloud/acc/... -v -count 1 -parallel 20 -timeout 360m -run TestAcc_NASInstance_CIFS
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation