### PR TITLE
Fix/hatoba cluster bug

### DIFF
--- a/nifcloud/resources/hatoba/cluster/schema.go
+++ b/nifcloud/resources/hatoba/cluster/schema.go
@@ -122,13 +122,11 @@ func newSchema() map[string]*schema.Schema {
 						Type:        schema.TypeString,
 						Description: "The name of the node pool.",
 						Required:    true,
-						ForceNew:    true,
 					},
 					"instance_type": {
 						Type:        schema.TypeString,
 						Description: "The instance type for node pool.",
 						Required:    true,
-						ForceNew:    true,
 					},
 					"node_count": {
 						Type:        schema.TypeInt,

--- a/nifcloud/resources/hatoba/cluster/update.go
+++ b/nifcloud/resources/hatoba/cluster/update.go
@@ -28,12 +28,12 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 			return diag.FromErr(fmt.Errorf("failed updating Hatoba cluster: %s", err))
 		}
 
+		d.SetId(d.Get("name").(string))
+
 		err := svc.WaitUntilClusterRunning(ctx, expandGetClusterInput(d))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("failed waiting for Hatoba cluster to become ready: %s", err))
 		}
-
-		d.SetId(d.Get("name").(string))
 	}
 
 	if d.HasChange("node_pools") {


### PR DESCRIPTION
## Description

Fix Hatoba cluster resource bug

* Delete ForceNew from node pool name and instance type
    * If you change the node pool definition, provider will recreate the cluster 😇 
* Fix to set the id before waiting.
    * if you do not change the resource id before call the waiter, waiter will keep waiting with the old cluster name.

## How Has This Been Tested?

- [x] apply example

```
make install
cd examples/hatoba_cluster
terraform init -plugin-dir ~/.terraform.d/plugins
terraform plan
terraform apply
```

- [x] fix tf file like below.

```
diff --git a/examples/hatoba_cluster/main.tf b/examples/hatoba_cluster/main.tf
index 05b84a7..a891ea9 100644
--- a/examples/hatoba_cluster/main.tf
+++ b/examples/hatoba_cluster/main.tf
@@ -11,8 +11,8 @@ provider "nifcloud" {
 }

 resource "nifcloud_hatoba_cluster" "example" {
-  name           = "cluster001"
-  description    = "memo"
+  name           = "cluster001upd"
+  description    = "memo upd"
   firewall_group = nifcloud_hatoba_firewall_group.example.name
   locations      = ["east-11"]

@@ -25,6 +25,11 @@ resource "nifcloud_hatoba_cluster" "example" {
   node_pools {
     name          = "default"
     instance_type = "medium"
+    node_count    = 3
+  }
+  node_pools {
+    name          = "pool1"
+    instance_type = "medium"
     node_count    = 1
   }
 }
```

- [x] apply again
    - [x] confirm that cluster is NOT recreated.
    - [x] confirm that apply successfully finished.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation