### PR TITLE
resource/nifcloud_volume: Fix save instance_id to state

### DIFF
--- a/nifcloud/resources/computing/volume/flattener.go
+++ b/nifcloud/resources/computing/volume/flattener.go
@@ -47,14 +47,12 @@ func flatten(d *schema.ResourceData, res *computing.DescribeVolumesResponse) err
 	if len(res.VolumeSet[0].AttachmentSet) != 0 {
 		instance := res.VolumeSet[0].AttachmentSet[0]
 
-		if _, ok := d.GetOk("instance_id"); ok {
-			if err := d.Set("instance_id", instance.InstanceId); err != nil {
-				return err
-			}
-		}
-
 		if _, ok := d.GetOk("instance_unique_id"); ok {
 			if err := d.Set("instance_unique_id", instance.InstanceUniqueId); err != nil {
+				return err
+			}
+		} else {
+			if err := d.Set("instance_id", instance.InstanceId); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Description

- Fix bugs for `nifcloud_volume` resource.
    - Fix to save instance_id to state when import

## How Has This Been Tested?

- [x] Run the acceptance test (only `TestAcc_Volume`)
- [x] Create instance and volume and attach instance in control panel ui and import example
```
make install
cd examples/volume
terraform init -plugin-dir ~/.terraform.d/plugins
terraform import nifcloud_volume.web volume001
terraform apply
```
## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation