### PR TITLE
Fix nat table for terrafrom v1.0.0

### DIFF
--- a/nifcloud/resources/network/nattable/schema.go
+++ b/nifcloud/resources/network/nattable/schema.go
@@ -67,12 +67,14 @@ func newSchema() map[string]*schema.Schema {
 						Type:         schema.TypeInt,
 						Description:  "The source port.",
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntBetween(0, 65535),
 					},
 					"translation_port": {
 						Type:         schema.TypeInt,
 						Description:  "The translation port.",
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntBetween(0, 65535),
 					},
 					"outbound_interface_network_id": {
@@ -117,6 +119,7 @@ func newSchema() map[string]*schema.Schema {
 						Type:         schema.TypeInt,
 						Description:  "The destination port.",
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntBetween(0, 65535),
 					},
 					"translation_address": {
@@ -129,6 +132,7 @@ func newSchema() map[string]*schema.Schema {
 						Type:         schema.TypeInt,
 						Description:  "The translation port.",
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntBetween(0, 65535),
 					},
 					"inbound_interface_network_id": {


### PR DESCRIPTION
## Description

After updated terraform 1.0.0, I noticed that when I plan after applying the example nat_table resource (in example/nat_table directory), differences are detected. (see below)

```
Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # nifcloud_nat_table.nat has been changed
  ~ resource "nifcloud_nat_table" "nat" {
        id           = "nat-0glomn3h"
        # (1 unchanged attribute hidden)

      + dnat {
          + description                    = "memo"
          + destination_port               = 0
          + inbound_interface_network_name = "pri"
          + protocol                       = "ALL"
          + rule_number                    = "1"
          + translation_address            = "192.168.1.1"
          + translation_port               = 0
        }
      - dnat {
          - description                    = "memo" -> null
          - inbound_interface_network_name = "pri" -> null
          - protocol                       = "ALL" -> null
          - rule_number                    = "1" -> null
          - translation_address            = "192.168.1.1" -> null
        }

        # (1 unchanged block hidden)
    }
```

attribute `*_port` is the computed attribute, so I added the `Computed` option to `*_port` schema.

## How Has This Been Tested?

```
make install
cd examples/nat_table
terraform init -plugin-dir ~/.terraform.d/plugins
terraform plan
terraform apply
terraform plan # confirm that diff is not detected
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation