### PR TITLE
resource/nifcloud_load_balancer: Fix bug of flatten options

### DIFF
--- a/nifcloud/resources/network/loadbalancer/flattener.go
+++ b/nifcloud/resources/network/loadbalancer/flattener.go
@@ -115,20 +115,22 @@ func flatten(d *schema.ResourceData, res *computing.DescribeLoadBalancersRespons
 	}
 
 	if loadBalancer.Option != nil {
-		if err := d.Set("session_stickiness_policy_enable", loadBalancer.Option.SessionStickinessPolicy.Enabled); err != nil {
-			return err
+		if loadBalancer.Option.SessionStickinessPolicy != nil {
+			if err := d.Set("session_stickiness_policy_enable", loadBalancer.Option.SessionStickinessPolicy.Enabled); err != nil {
+				return err
+			}
+			if err := d.Set("session_stickiness_policy_expiration_period", loadBalancer.Option.SessionStickinessPolicy.ExpirationPeriod); err != nil {
+				return err
+			}
 		}
-		if err := d.Set("session_stickiness_policy_expiration_period", loadBalancer.Option.SessionStickinessPolicy.ExpirationPeriod); err != nil {
-			return err
-		}
-	}
 
-	if loadBalancer.Option != nil {
-		if err := d.Set("sorry_page_enable", loadBalancer.Option.SorryPage.Enabled); err != nil {
-			return err
-		}
-		if err := d.Set("sorry_page_status_code", loadBalancer.Option.SorryPage.StatusCode); err != nil {
-			return err
+		if loadBalancer.Option.SorryPage != nil {
+			if err := d.Set("sorry_page_enable", loadBalancer.Option.SorryPage.Enabled); err != nil {
+				return err
+			}
+			if err := d.Set("sorry_page_status_code", loadBalancer.Option.SorryPage.StatusCode); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/nifcloud/resources/network/loadbalancerlistener/flattener.go
+++ b/nifcloud/resources/network/loadbalancerlistener/flattener.go
@@ -91,20 +91,22 @@ func flatten(d *schema.ResourceData, res *computing.DescribeLoadBalancersRespons
 	}
 
 	if loadBalancer.Option != nil {
-		if err := d.Set("session_stickiness_policy_enable", loadBalancer.Option.SessionStickinessPolicy.Enabled); err != nil {
-			return err
+		if loadBalancer.Option.SessionStickinessPolicy != nil {
+			if err := d.Set("session_stickiness_policy_enable", loadBalancer.Option.SessionStickinessPolicy.Enabled); err != nil {
+				return err
+			}
+			if err := d.Set("session_stickiness_policy_expiration_period", loadBalancer.Option.SessionStickinessPolicy.ExpirationPeriod); err != nil {
+				return err
+			}
 		}
-		if err := d.Set("session_stickiness_policy_expiration_period", loadBalancer.Option.SessionStickinessPolicy.ExpirationPeriod); err != nil {
-			return err
-		}
-	}
 
-	if loadBalancer.Option != nil {
-		if err := d.Set("sorry_page_enable", loadBalancer.Option.SorryPage.Enabled); err != nil {
-			return err
-		}
-		if err := d.Set("sorry_page_status_code", loadBalancer.Option.SorryPage.StatusCode); err != nil {
-			return err
+		if loadBalancer.Option.SorryPage != nil {
+			if err := d.Set("sorry_page_enable", loadBalancer.Option.SorryPage.Enabled); err != nil {
+				return err
+			}
+			if err := d.Set("sorry_page_status_code", loadBalancer.Option.SorryPage.StatusCode); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

- Fix bugs for `nifcloud_load_balancer` `nifcloud_load_balancer_listerner` resource.
    - Fix to save option in the case of nil

## How Has This Been Tested?

- [x] Run the acceptance test (only `TestAcc_LoadBalancer`)
- [x] Create Load Balancer with either sorry page or session stickiness policy enabled.
```
make install
cd examples/loadbalancer/
vim main.tf
+  sorry_page_enable  = true
terraform init -plugin-dir ~/.terraform.d/plugins
terraform apply
```
## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation