### PR TITLE
Add debug logger to dump the API request and response

### DIFF
--- a/nifcloud/provider_config.go
+++ b/nifcloud/provider_config.go
@@ -2,6 +2,7 @@ package nifcloud
 
 import (
 	"context"
+	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -11,6 +12,12 @@ import (
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/client"
 )
 
+type debugLogger struct{}
+
+func (l debugLogger) Log(v ...interface{}) {
+	log.Println(v...)
+}
+
 // configure implements schema.ConfigureContextFunc
 func configure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	cfg := nifcloud.NewConfig(
@@ -19,6 +26,8 @@ func configure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Dia
 		d.Get("region").(string),
 	)
 	cfg.Retryer = aws.NoOpRetryer{}
+	cfg.LogLevel = aws.LogDebugWithHTTPBody
+	cfg.Logger = &debugLogger{}
 
 	client := client.New(cfg)
 	return client, nil


### PR DESCRIPTION
# Description
* Add logger that dump the API request and response.

## How Has This Been Tested?

- [ ]  Buld with `make install` command, and apply example with `TF_LOG=DEBUG` option.
    - You can see raw API request and response.

```:console
make install
cd examples/key_pair
terraform init -plugin-dir ~/.terraform.d/plugins
terraform plan
TF_LOG=debug terraform apply
TF_LOG=debug terraform destroy
```

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation