### PR TITLE
resource/nifcloud_route_table Fix to exclude EnableVgwRoutePropagation

### DIFF
--- a/nifcloud/resources/network/routetable/flattener.go
+++ b/nifcloud/resources/network/routetable/flattener.go
@@ -26,6 +26,11 @@ func flatten(d *schema.ResourceData, res *computing.DescribeRouteTablesResponse)
 
 	var routes []map[string]interface{}
 	for _, r := range routeTable.RouteSet {
+		// for vpn connection of IPsec VTI
+		if nifcloud.StringValue(r.Origin) == "EnableVgwRoutePropagation" {
+			continue
+		}
+
 		route := map[string]interface{}{
 			"ip_address": r.IpAddress,
 			"cidr_block": r.DestinationCidrBlock,


### PR DESCRIPTION
## Description

*  resource/nifcloud_route_table Fix to exclude EnableVgwRoutePropagation

## How Has This Been Tested?

- [x] Acceptable 🍋
- [x] Run the acceptance test.
```
TF_ACC=1 go test ./nifcloud/acc/... -v -count 1 -parallel 20 -timeout 360m -run TestAcc_RouteTable
```

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation