### PR TITLE
Add nifcloud_dns_record resource

### DIFF
--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -1,0 +1,88 @@
+---
+page_title: "NIFCLOUD: nifcloud_dns_record"
+subcategory: "DNS"
+description: |-
+  Provides a DNS record resource.
+---
+
+# nifcloud_dns_record
+
+Provides a DNS record resource.
+
+## Example Usage
+
+```hcl
+terraform {
+  required_providers {
+    nifcloud = {
+      source = "nifcloud/nifcloud"
+    }
+  }
+}
+
+resource "nifcloud_dns_record" "example" {
+  zone_id = nifcloud_dns_zone.example.id
+  name    = "test.example.test"
+  type    = "A"
+  ttl     = "300"
+  record  = "192.168.0.1"
+  comment = "memo"
+}
+
+resource "nifcloud_dns_zone" "example" {
+  name    = "example.test"
+  comment = "memo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone_id` - (Required) The ID of the hosted zone to contain this record.
+* `name` - (Required) The name of the record.
+* `type` - (Required) The type of the record.
+* `record` - (Required) The value of the record.
+* `ttl` - (Optional) The TTL of the record.
+* `weighted_routing_policy` - (Optional) The configs for weighted routing policy. Conflicts with failover_routing_policy. see [weighted_routing_policy](#weighted_routing_policy)
+* `failover_routing_policy` - (Optional) The configs for failover routing policy. Conflicts with weighted_routing_policy. see [failover_routing_policy](#failover_routing_policy)
+* `default_host` - (Optional) The default host if using LBR.
+* `comment` - (Optional) The comment of the record.
+
+### weighted_routing_policy
+
+#### Arguments
+
+* `weight` - (Optional) The record weighted value.
+
+### failover_routing_policy
+
+#### Arguments
+
+* `type` - (Optional) The record failover type.
+* `health_check` - (Optional) The configs for health check if using failover. see [health_check](#health_check)
+
+### health_check
+
+#### Arguments
+
+* `protocol` - (Optional) The health check protocol.
+* `ip_address` - (Optional) The health check IP address.
+* `port` - (Optional) The health check port.
+* `resource_path` - (Optional) The health check resource path if using HTTP or HTTPS protocol.
+* `resource_domain` - (Optional) The health check resource domain if using HTTP or HTTPS protocol.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `set_identifier` - (Optional) The unique identifier to differentiate records with routing policies from one another.
+
+## Import
+
+nifcloud_dns_zone can be imported using the `set_identifier`, `zone_id`.
+separated by underscores ( _ ). All parts are required.
+
+```
+$ terraform import nifcloud_dns_record.example XXXXXXXXX_example.test
+```

--- a/examples/dns_record/main.tf
+++ b/examples/dns_record/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    nifcloud = {
+      source = "nifcloud/nifcloud"
+    }
+  }
+}
+
+resource "nifcloud_dns_record" "example" {
+  zone_id = nifcloud_dns_zone.example.id
+  name    = "test.example.test"
+  type    = "A"
+  ttl     = "300"
+  record  = ["192.168.0.1"]
+  comment = "memo"
+}
+
+resource "nifcloud_dns_zone" "example" {
+  name    = "example.test"
+  comment = "memo"
+}
+

--- a/nifcloud/acc/dns_record_test.go
+++ b/nifcloud/acc/dns_record_test.go
@@ -1,0 +1,319 @@
+package acc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws/awserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+	"github.com/nifcloud/nifcloud-sdk-go/service/dns"
+	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/client"
+)
+
+var dnsRecordName = os.Getenv("TF_VAR_dns_record_name")
+
+func init() {
+	resource.AddTestSweepers("nifcloud_dns_record", &resource.Sweeper{
+		Name: "nifcloud_dns_record",
+		F:    testSweepDnsRecord,
+	})
+}
+
+func TestAcc_DnsRecord_Weight(t *testing.T) {
+	var record dns.ResourceRecordSets
+
+	resourceName := "nifcloud_dns_record.basic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDnsRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecord(t, "testdata/dns_record_weight.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordExists(resourceName, &record),
+					testAccCheckDnsRecordWeightValues(&record),
+					resource.TestCheckResourceAttr(resourceName, "zone_id", dnsZoneName),
+					resource.TestCheckResourceAttr(resourceName, "name", dnsRecordName),
+					resource.TestCheckResourceAttr(resourceName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "60"),
+					resource.TestCheckResourceAttr(resourceName, "record", "192.0.2.1"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "tfacc-memo"),
+					resource.TestCheckResourceAttr(resourceName, "weighted_routing_policy.0.weight", "90"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccDnsRecordImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"weighted_routing_policy.",
+				},
+			},
+		},
+	})
+}
+
+func TestAcc_DnsRecord_Failover(t *testing.T) {
+	var record dns.ResourceRecordSets
+
+	resourceName := "nifcloud_dns_record.basic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDnsRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecord(t, "testdata/dns_record_failover.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordExists(resourceName, &record),
+					testAccCheckDnsRecordFailoverValues(&record),
+					resource.TestCheckResourceAttr(resourceName, "zone_id", dnsZoneName),
+					resource.TestCheckResourceAttr(resourceName, "name", dnsRecordName),
+					resource.TestCheckResourceAttr(resourceName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "60"),
+					resource.TestCheckResourceAttr(resourceName, "record", "192.0.2.1"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "tfacc-memo"),
+					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.0.type", "PRIMARY"),
+					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.0.health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.0.health_check.0.ip_address", "192.0.2.2"),
+					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.0.health_check.0.port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.0.health_check.0.resource_path", "test"),
+					resource.TestCheckResourceAttr(resourceName, "failover_routing_policy.0.health_check.0.resource_domain", "example.test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccDnsRecordImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"failover_routing_policy.",
+				},
+			},
+		},
+	})
+}
+
+func testAccDnsRecord(t *testing.T, fileName string) string {
+	b, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func testAccCheckDnsRecordExists(n string, dnsRecord *dns.ResourceRecordSets) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		saved, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("no dnsZone resource: %s", n)
+		}
+
+		if saved.Primary.ID == "" {
+			return fmt.Errorf("no dnsZone id is set")
+		}
+
+		svc := testAccProvider.Meta().(*client.Client).DNS
+		res, err := svc.ListResourceRecordSetsRequest(&dns.ListResourceRecordSetsInput{
+			Identifier: nifcloud.String(saved.Primary.ID),
+			ZoneID:     nifcloud.String(dnsZoneName),
+		}).Send(context.Background())
+
+		if err != nil {
+			return err
+		}
+
+		foundDnsRecord := res.ResourceRecordSets[0]
+
+		if nifcloud.StringValue(foundDnsRecord.SetIdentifier) != saved.Primary.ID {
+			return fmt.Errorf("dnsRecord does not found in cloud: %s", saved.Primary.ID)
+		}
+
+		*dnsRecord = foundDnsRecord
+		return nil
+	}
+}
+
+func testAccCheckDnsRecordWeightValues(dnsRecord *dns.ResourceRecordSets) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if nifcloud.StringValue(dnsRecord.Name) != dnsRecordName {
+			return fmt.Errorf("bad name state, expected %s, got: %#v", dnsRecordName, dnsRecord.Name)
+		}
+
+		if nifcloud.StringValue(dnsRecord.Type) != "A" {
+			return fmt.Errorf("bad comment state, expected \"A\", got: %#v", dnsRecord.Type)
+		}
+
+		if nifcloud.Int64Value(dnsRecord.TTL) != 60 {
+			return fmt.Errorf("bad comment state, expected 60, got: %#v", dnsRecord.TTL)
+		}
+
+		if nifcloud.StringValue(dnsRecord.ResourceRecords[0].Value) != "192.0.2.1" {
+			return fmt.Errorf("bad comment state, expected \"192.0.2.1\", got: %#v", dnsRecord.ResourceRecords[0].Value)
+		}
+
+		if nifcloud.StringValue(dnsRecord.XniftyComment) != "tfacc-memo" {
+			return fmt.Errorf("bad comment state, expected \"tfacc-memo\", got: %#v", dnsRecord.XniftyComment)
+		}
+
+		if nifcloud.Int64Value(dnsRecord.Weight) != 90 {
+			return fmt.Errorf("bad comment state, expected \"90\", got: %#v", dnsRecord.Weight)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDnsRecordFailoverValues(dnsRecord *dns.ResourceRecordSets) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if nifcloud.StringValue(dnsRecord.Name) != dnsRecordName {
+			return fmt.Errorf("bad name state, expected %s, got: %#v", dnsRecordName, dnsRecord.Name)
+		}
+
+		if nifcloud.StringValue(dnsRecord.Type) != "A" {
+			return fmt.Errorf("bad comment state, expected \"A\", got: %#v", dnsRecord.Type)
+		}
+
+		if nifcloud.Int64Value(dnsRecord.TTL) != 60 {
+			return fmt.Errorf("bad comment state, expected 60, got: %#v", dnsRecord.TTL)
+		}
+
+		if nifcloud.StringValue(dnsRecord.ResourceRecords[0].Value) != "192.0.2.1" {
+			return fmt.Errorf("bad comment state, expected \"192.0.2.1\", got: %#v", dnsRecord.ResourceRecords[0].Value)
+		}
+
+		if nifcloud.StringValue(dnsRecord.XniftyComment) != "tfacc-memo" {
+			return fmt.Errorf("bad comment state, expected \"tfacc-memo\", got: %#v", dnsRecord.XniftyComment)
+		}
+
+		if nifcloud.StringValue(dnsRecord.Failover) != "PRIMARY" {
+			return fmt.Errorf("bad comment state, expected \"PRIMARY\", got: %#v", dnsRecord.Failover)
+		}
+
+		if nifcloud.StringValue(dnsRecord.XniftyHealthCheckConfig.Protocol) != "HTTPS" {
+			return fmt.Errorf("bad comment state, expected \"HTTPS\", got: %#v", dnsRecord.XniftyHealthCheckConfig.Protocol)
+		}
+
+		if nifcloud.StringValue(dnsRecord.XniftyHealthCheckConfig.IPAddress) != "192.0.2.2" {
+			return fmt.Errorf("bad comment state, expected \"192.0.2.2\", got: %#v", dnsRecord.XniftyHealthCheckConfig.IPAddress)
+		}
+
+		if nifcloud.Int64Value(dnsRecord.XniftyHealthCheckConfig.Port) != 443 {
+			return fmt.Errorf("bad comment state, expected \"443\", got: %#v", dnsRecord.XniftyHealthCheckConfig.Port)
+		}
+
+		if nifcloud.StringValue(dnsRecord.XniftyHealthCheckConfig.ResourcePath) != "test" {
+			return fmt.Errorf("bad comment state, expected \"test\", got: %#v", dnsRecord.XniftyHealthCheckConfig.ResourcePath)
+		}
+
+		if nifcloud.StringValue(dnsRecord.XniftyHealthCheckConfig.FullyQualifiedDomainName) != "example.test" {
+			return fmt.Errorf("bad comment state, expected \"example.test\", got: %#v", dnsRecord.XniftyHealthCheckConfig.FullyQualifiedDomainName)
+		}
+
+		return nil
+	}
+}
+
+func testAccDnsRecordResourceDestroy(s *terraform.State) error {
+	svc := testAccProvider.Meta().(*client.Client).DNS
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "nifcloud_dns_record" {
+			continue
+		}
+
+		res, err := svc.ListResourceRecordSetsRequest(&dns.ListResourceRecordSetsInput{
+			Identifier: nifcloud.String(rs.Primary.ID),
+			ZoneID:     nifcloud.String(dnsZoneName),
+		}).Send(context.Background())
+
+		if err != nil {
+			var awsErr awserr.Error
+			if errors.As(err, &awsErr) && awsErr.Code() == "NoSuchHostedZone" {
+				return nil
+			}
+			return fmt.Errorf("failed ListResourceRecordSetsRequest: %s", err)
+		}
+
+		if res.ResourceRecordSets[0].Name == nifcloud.String(rs.Primary.ID) {
+			return fmt.Errorf("dnsRecord (%s) still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testSweepDnsRecord(region string) error {
+	ctx := context.Background()
+	svc := sharedClientForRegion(region).DNS
+
+	res, err := svc.ListResourceRecordSetsRequest(&dns.ListResourceRecordSetsInput{
+		ZoneID: nifcloud.String(dnsZoneName),
+	}).Send(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, resourceRecordSet := range res.ResourceRecordSets {
+		if strings.HasPrefix(nifcloud.StringValue(resourceRecordSet.XniftyComment), prefix) {
+			input := &dns.ChangeResourceRecordSetsInput{
+				ZoneID: nifcloud.String(dnsZoneName),
+				RequestChangeBatch: &dns.RequestChangeBatch{
+					ListOfRequestChanges: []dns.RequestChanges{{
+						RequestChange: &dns.RequestChange{
+							Action: nifcloud.String("DELETE"),
+							RequestResourceRecordSet: &dns.RequestResourceRecordSet{
+								Name:              resourceRecordSet.Name,
+								SetIdentifier:     resourceRecordSet.SetIdentifier,
+								TTL:               resourceRecordSet.TTL,
+								Type:              resourceRecordSet.Type,
+								XniftyComment:     resourceRecordSet.XniftyComment,
+								XniftyDefaultHost: resourceRecordSet.XniftyDefaultHost,
+								ListOfRequestResourceRecords: []dns.RequestResourceRecords{{
+									RequestResourceRecord: &dns.RequestResourceRecord{
+										Value: resourceRecordSet.ResourceRecords[0].Value,
+									},
+								}},
+							},
+						},
+					}},
+				},
+			}
+
+			_, err := svc.ChangeResourceRecordSetsRequest(input).Send(ctx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func testAccDnsRecordImportStateIDFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("not found: %s", resourceName)
+		}
+
+		setIdentifier := rs.Primary.Attributes["set_identifier"]
+		zoneId := rs.Primary.Attributes["zone_id"]
+
+		var parts []string
+		parts = append(parts, setIdentifier)
+		parts = append(parts, zoneId)
+
+		id := strings.Join(parts, "_")
+		return id, nil
+	}
+}

--- a/nifcloud/acc/dns_zone_test.go
+++ b/nifcloud/acc/dns_zone_test.go
@@ -23,6 +23,9 @@ func init() {
 	resource.AddTestSweepers("nifcloud_dns_zone", &resource.Sweeper{
 		Name: "nifcloud_dns_zone",
 		F:    testSweepDnsZone,
+		Dependencies: []string{
+			"nifcloud_dns_record",
+		},
 	})
 }
 

--- a/nifcloud/acc/testdata/dns_record_failover.tf
+++ b/nifcloud/acc/testdata/dns_record_failover.tf
@@ -1,0 +1,33 @@
+resource "nifcloud_dns_record" "basic" {
+  zone_id        = nifcloud_dns_zone.basic.id
+  name           = var.dns_record_name
+  type           = "A"
+  ttl            = 60
+  record         = "192.0.2.1"
+  comment        = "tfacc-memo"
+  failover_routing_policy {
+    type = "PRIMARY"
+    health_check {
+      protocol = "HTTPS"
+      ip_address = "192.0.2.2"
+      port = 443
+      resource_path = "test"
+      resource_domain = "example.test"
+    }
+  }
+}
+
+resource "nifcloud_dns_zone" "basic" {
+  name    = var.dns_zone_name
+  comment = "tfacc-memo"
+}
+
+variable "dns_record_name" {
+    description = "test dns record"
+    type        = string
+}
+
+variable "dns_zone_name" {
+    description = "test dns zone"
+    type        = string
+}

--- a/nifcloud/acc/testdata/dns_record_weight.tf
+++ b/nifcloud/acc/testdata/dns_record_weight.tf
@@ -1,0 +1,26 @@
+resource "nifcloud_dns_record" "basic" {
+  zone_id        = nifcloud_dns_zone.basic.id
+  name           = var.dns_record_name
+  type           = "A"
+  ttl            = 60
+  record         = "192.0.2.1"
+  comment        = "tfacc-memo"
+  weighted_routing_policy {
+    weight = 90
+  }
+}
+
+resource "nifcloud_dns_zone" "basic" {
+  name    = var.dns_zone_name
+  comment = "tfacc-memo"
+}
+
+variable "dns_record_name" {
+    description = "test dns record"
+    type        = string
+}
+
+variable "dns_zone_name" {
+    description = "test dns zone"
+    type        = string
+}

--- a/nifcloud/provider.go
+++ b/nifcloud/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/resources/computing/securitygrouprule"
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/resources/computing/separateinstancerule"
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/resources/computing/volume"
+	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/resources/dns/record"
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/resources/dns/zone"
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/resources/hatoba/cluster"
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/resources/hatoba/firewallgroup"
@@ -72,6 +73,7 @@ func Provider() *schema.Provider {
 			"nifcloud_db_security_group":      dbsecuritygroup.New(),
 			"nifcloud_dhcp_config":            dhcpconfig.New(),
 			"nifcloud_dhcp_option":            dhcpoption.New(),
+			"nifcloud_dns_record":             record.New(),
 			"nifcloud_dns_zone":               zone.New(),
 			"nifcloud_elastic_ip":             elasticip.New(),
 			"nifcloud_elb":                    elb.New(),

--- a/nifcloud/resources/dns/record/create.go
+++ b/nifcloud/resources/dns/record/create.go
@@ -1,0 +1,24 @@
+package record
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/client"
+)
+
+func create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	input := expandCreateChangeResourceRecordSetsInput(d)
+
+	svc := meta.(*client.Client).DNS
+	req := svc.ChangeResourceRecordSetsRequest(input)
+
+	_, err := req.Send(ctx)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed creating dns record: %s", err))
+	}
+
+	return read(ctx, d, meta)
+}

--- a/nifcloud/resources/dns/record/delete.go
+++ b/nifcloud/resources/dns/record/delete.go
@@ -1,0 +1,25 @@
+package record
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/client"
+)
+
+func delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	input := expandDeleteChangeResourceRecordSetsInput(d)
+
+	svc := meta.(*client.Client).DNS
+	req := svc.ChangeResourceRecordSetsRequest(input)
+
+	if _, err := req.Send(ctx); err != nil {
+		return diag.FromErr(fmt.Errorf("failed deleting dns record error: %s", err))
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/nifcloud/resources/dns/record/expander.go
+++ b/nifcloud/resources/dns/record/expander.go
@@ -1,0 +1,92 @@
+package record
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+	"github.com/nifcloud/nifcloud-sdk-go/service/dns"
+)
+
+func expandCreateChangeResourceRecordSetsInput(d *schema.ResourceData) *dns.ChangeResourceRecordSetsInput {
+	return &dns.ChangeResourceRecordSetsInput{
+		ZoneID: nifcloud.String(d.Get("zone_id").(string)),
+		RequestChangeBatch: &dns.RequestChangeBatch{
+			ListOfRequestChanges: []dns.RequestChanges{{
+				RequestChange: &dns.RequestChange{
+					Action:                   nifcloud.String("CREATE"),
+					RequestResourceRecordSet: expandRequestResourceRecordSetInput(d),
+				},
+			}},
+		},
+	}
+}
+
+func expandListResourceRecordSets(d *schema.ResourceData) *dns.ListResourceRecordSetsInput {
+	return &dns.ListResourceRecordSetsInput{
+		Identifier: nifcloud.String(d.Id()),
+		Name:       nifcloud.String(d.Get("name").(string)),
+		Type:       nifcloud.String(d.Get("type").(string)),
+		ZoneID:     nifcloud.String(d.Get("zone_id").(string)),
+	}
+}
+
+func expandDeleteChangeResourceRecordSetsInput(d *schema.ResourceData) *dns.ChangeResourceRecordSetsInput {
+	return &dns.ChangeResourceRecordSetsInput{
+		ZoneID: nifcloud.String(d.Get("zone_id").(string)),
+		RequestChangeBatch: &dns.RequestChangeBatch{
+			ListOfRequestChanges: []dns.RequestChanges{{
+				RequestChange: &dns.RequestChange{
+					Action:                   nifcloud.String("DELETE"),
+					RequestResourceRecordSet: expandRequestResourceRecordSetInput(d),
+				},
+			}},
+		},
+	}
+}
+
+func expandRequestResourceRecordSetInput(d *schema.ResourceData) *dns.RequestResourceRecordSet {
+	input := &dns.RequestResourceRecordSet{
+		Name:              nifcloud.String(d.Get("name").(string)),
+		SetIdentifier:     nifcloud.String(d.Get("set_identifier").(string)),
+		TTL:               nifcloud.Int64(int64(d.Get("ttl").(int))),
+		Type:              nifcloud.String(d.Get("type").(string)),
+		XniftyComment:     nifcloud.String(d.Get("comment").(string)),
+		XniftyDefaultHost: nifcloud.String(d.Get("default_host").(string)),
+		ListOfRequestResourceRecords: []dns.RequestResourceRecords{{
+			RequestResourceRecord: &dns.RequestResourceRecord{
+				Value: nifcloud.String(d.Get("record").(string)),
+			},
+		}},
+	}
+
+	weightSet := d.Get("weighted_routing_policy").([]interface{})
+	if len(weightSet) != 0 {
+		weight := weightSet[0].(map[string]interface{})
+
+		if value, ok := weight["weight"]; ok {
+			input.Weight = nifcloud.Int64(int64(value.(int)))
+		}
+	}
+
+	failoverSet := d.Get("failover_routing_policy").([]interface{})
+	if len(failoverSet) != 0 {
+		failover := failoverSet[0].(map[string]interface{})
+
+		if value, ok := failover["type"]; ok {
+			input.Failover = nifcloud.String(value.(string))
+		}
+
+		if len(failover["health_check"].([]interface{})) != 0 {
+			healthCheckSet := failover["health_check"].([]interface{})
+			healthCheck := healthCheckSet[0].(map[string]interface{})
+			input.RequestXniftyHealthCheckConfig = &dns.RequestXniftyHealthCheckConfig{
+				FullyQualifiedDomainName: nifcloud.String(healthCheck["resource_domain"].(string)),
+				IPAddress:                nifcloud.String(healthCheck["ip_address"].(string)),
+				Port:                     nifcloud.Int64(int64(healthCheck["port"].(int))),
+				Protocol:                 nifcloud.String(healthCheck["protocol"].(string)),
+				ResourcePath:             nifcloud.String(healthCheck["resource_path"].(string)),
+			}
+		}
+	}
+
+	return input
+}

--- a/nifcloud/resources/dns/record/expander_test.go
+++ b/nifcloud/resources/dns/record/expander_test.go
@@ -1,0 +1,263 @@
+package record
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+	"github.com/nifcloud/nifcloud-sdk-go/service/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandCreateChangeResourceRecordSetsInput(t *testing.T) {
+	healthCheck := map[string]interface{}{
+		"protocol":        "HTTP",
+		"ip_address":      "192.0.2.1",
+		"port":            8080,
+		"resource_path":   "test_resource_path",
+		"resource_domain": "test_resource_domain",
+	}
+	rd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{
+		"zone_id": "test_zone_id",
+		"name":    "test_name",
+		"type":    "A",
+		"record":  "192.0.2.1",
+		"ttl":     60,
+		"weighted_routing_policy": []interface{}{map[string]interface{}{
+			"weight": 60,
+		}},
+		"failover_routing_policy": []interface{}{map[string]interface{}{
+			"type":         "PRIMARY",
+			"health_check": []interface{}{healthCheck},
+		}},
+		"default_host":   "test_default_host",
+		"comment":        "test_comment",
+		"set_identifier": "test_set_identifier",
+	})
+
+	tests := []struct {
+		name string
+		args *schema.ResourceData
+		want *dns.ChangeResourceRecordSetsInput
+	}{
+		{
+			name: "expands the resource data",
+			args: rd,
+			want: &dns.ChangeResourceRecordSetsInput{
+				ZoneID: nifcloud.String("test_zone_id"),
+				RequestChangeBatch: &dns.RequestChangeBatch{
+					ListOfRequestChanges: []dns.RequestChanges{{
+						RequestChange: &dns.RequestChange{
+							Action: nifcloud.String("CREATE"),
+							RequestResourceRecordSet: &dns.RequestResourceRecordSet{
+								Failover:          nifcloud.String("PRIMARY"),
+								Name:              nifcloud.String("test_name"),
+								SetIdentifier:     nifcloud.String("test_set_identifier"),
+								TTL:               nifcloud.Int64(60),
+								Type:              nifcloud.String("A"),
+								Weight:            nifcloud.Int64(60),
+								XniftyComment:     nifcloud.String("test_comment"),
+								XniftyDefaultHost: nifcloud.String("test_default_host"),
+								ListOfRequestResourceRecords: []dns.RequestResourceRecords{{
+									RequestResourceRecord: &dns.RequestResourceRecord{
+										Value: nifcloud.String("192.0.2.1"),
+									},
+								}},
+								RequestXniftyHealthCheckConfig: &dns.RequestXniftyHealthCheckConfig{
+									FullyQualifiedDomainName: nifcloud.String("test_resource_domain"),
+									IPAddress:                nifcloud.String("192.0.2.1"),
+									Port:                     nifcloud.Int64(8080),
+									Protocol:                 nifcloud.String("HTTP"),
+									ResourcePath:             nifcloud.String("test_resource_path"),
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandCreateChangeResourceRecordSetsInput(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExpandListResourceRecordSets(t *testing.T) {
+	rd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{
+		"zone_id": "test_zone_id",
+		"type":    "A",
+		"name":    "test_name",
+	})
+	rd.SetId("test_set_identifier")
+
+	tests := []struct {
+		name string
+		args *schema.ResourceData
+		want *dns.ListResourceRecordSetsInput
+	}{
+		{
+			name: "expands the resource data",
+			args: rd,
+			want: &dns.ListResourceRecordSetsInput{
+				Identifier: nifcloud.String("test_set_identifier"),
+				Name:       nifcloud.String("test_name"),
+				Type:       nifcloud.String("A"),
+				ZoneID:     nifcloud.String("test_zone_id"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandListResourceRecordSets(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExpandDeleteChangeResourceRecordSetsInput(t *testing.T) {
+	healthCheck := map[string]interface{}{
+		"protocol":        "HTTP",
+		"ip_address":      "192.0.2.1",
+		"port":            8080,
+		"resource_path":   "test_resource_path",
+		"resource_domain": "test_resource_domain",
+	}
+	rd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{
+		"zone_id": "test_zone_id",
+		"name":    "test_name",
+		"type":    "A",
+		"record":  "192.0.2.1",
+		"ttl":     60,
+		"weighted_routing_policy": []interface{}{map[string]interface{}{
+			"weight": 60,
+		}},
+		"failover_routing_policy": []interface{}{map[string]interface{}{
+			"type":         "PRIMARY",
+			"health_check": []interface{}{healthCheck},
+		}},
+		"default_host":   "test_default_host",
+		"comment":        "test_comment",
+		"set_identifier": "test_set_identifier",
+	})
+
+	tests := []struct {
+		name string
+		args *schema.ResourceData
+		want *dns.ChangeResourceRecordSetsInput
+	}{
+		{
+			name: "expands the resource data",
+			args: rd,
+			want: &dns.ChangeResourceRecordSetsInput{
+				ZoneID: nifcloud.String("test_zone_id"),
+				RequestChangeBatch: &dns.RequestChangeBatch{
+					ListOfRequestChanges: []dns.RequestChanges{{
+						RequestChange: &dns.RequestChange{
+							Action: nifcloud.String("DELETE"),
+							RequestResourceRecordSet: &dns.RequestResourceRecordSet{
+								Failover:          nifcloud.String("PRIMARY"),
+								Name:              nifcloud.String("test_name"),
+								SetIdentifier:     nifcloud.String("test_set_identifier"),
+								TTL:               nifcloud.Int64(60),
+								Type:              nifcloud.String("A"),
+								Weight:            nifcloud.Int64(60),
+								XniftyComment:     nifcloud.String("test_comment"),
+								XniftyDefaultHost: nifcloud.String("test_default_host"),
+								ListOfRequestResourceRecords: []dns.RequestResourceRecords{{
+									RequestResourceRecord: &dns.RequestResourceRecord{
+										Value: nifcloud.String("192.0.2.1"),
+									},
+								}},
+								RequestXniftyHealthCheckConfig: &dns.RequestXniftyHealthCheckConfig{
+									FullyQualifiedDomainName: nifcloud.String("test_resource_domain"),
+									IPAddress:                nifcloud.String("192.0.2.1"),
+									Port:                     nifcloud.Int64(8080),
+									Protocol:                 nifcloud.String("HTTP"),
+									ResourcePath:             nifcloud.String("test_resource_path"),
+								},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandDeleteChangeResourceRecordSetsInput(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExpandRequestResourceRecordSetInput(t *testing.T) {
+	healthCheck := map[string]interface{}{
+		"protocol":        "HTTP",
+		"ip_address":      "192.0.2.1",
+		"port":            8080,
+		"resource_path":   "test_resource_path",
+		"resource_domain": "test_resource_domain",
+	}
+	rd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{
+		"name":   "test_name",
+		"type":   "A",
+		"record": "192.0.2.1",
+		"ttl":    60,
+		"weighted_routing_policy": []interface{}{map[string]interface{}{
+			"weight": 60,
+		}},
+		"failover_routing_policy": []interface{}{map[string]interface{}{
+			"type":         "PRIMARY",
+			"health_check": []interface{}{healthCheck},
+		}},
+		"default_host":   "test_default_host",
+		"comment":        "test_comment",
+		"set_identifier": "test_set_identifier",
+	})
+
+	tests := []struct {
+		name string
+		args *schema.ResourceData
+		want *dns.RequestResourceRecordSet
+	}{
+		{
+			name: "expands the resource data",
+			args: rd,
+			want: &dns.RequestResourceRecordSet{
+				Failover:          nifcloud.String("PRIMARY"),
+				Name:              nifcloud.String("test_name"),
+				SetIdentifier:     nifcloud.String("test_set_identifier"),
+				TTL:               nifcloud.Int64(60),
+				Type:              nifcloud.String("A"),
+				Weight:            nifcloud.Int64(60),
+				XniftyComment:     nifcloud.String("test_comment"),
+				XniftyDefaultHost: nifcloud.String("test_default_host"),
+				ListOfRequestResourceRecords: []dns.RequestResourceRecords{{
+					RequestResourceRecord: &dns.RequestResourceRecord{
+						Value: nifcloud.String("192.0.2.1"),
+					},
+				}},
+				RequestXniftyHealthCheckConfig: &dns.RequestXniftyHealthCheckConfig{
+					FullyQualifiedDomainName: nifcloud.String("test_resource_domain"),
+					IPAddress:                nifcloud.String("192.0.2.1"),
+					Port:                     nifcloud.Int64(8080),
+					Protocol:                 nifcloud.String("HTTP"),
+					ResourcePath:             nifcloud.String("test_resource_path"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandRequestResourceRecordSetInput(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/nifcloud/resources/dns/record/flattener.go
+++ b/nifcloud/resources/dns/record/flattener.go
@@ -1,0 +1,106 @@
+package record
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+	"github.com/nifcloud/nifcloud-sdk-go/service/dns"
+)
+
+func flatten(d *schema.ResourceData, res *dns.ListResourceRecordSetsResponse) error {
+	if res == nil || len(res.ResourceRecordSets) == 0 {
+		d.SetId("")
+		return nil
+	}
+
+	var resourceRecordSet dns.ResourceRecordSets
+
+	for _, s := range res.ResourceRecordSets {
+		if nifcloud.StringValue(s.SetIdentifier) == d.Id() {
+			resourceRecordSet = s
+		}
+	}
+
+	if nifcloud.StringValue(resourceRecordSet.SetIdentifier) != d.Id() {
+		return fmt.Errorf("unable to find dns record within: %#v", resourceRecordSet)
+	}
+
+	if err := d.Set("set_identifier", resourceRecordSet.SetIdentifier); err != nil {
+		return err
+	}
+
+	if err := d.Set("name", resourceRecordSet.Name); err != nil {
+		return err
+	}
+
+	if err := d.Set("type", resourceRecordSet.Type); err != nil {
+		return err
+	}
+
+	if err := d.Set("record", resourceRecordSet.ResourceRecords[0].Value); err != nil {
+		return err
+	}
+
+	if err := d.Set("ttl", resourceRecordSet.TTL); err != nil {
+		return err
+	}
+
+	if _, ok := d.GetOk("weighted_routing_policy"); ok {
+		if err := d.Set("weighted_routing_policy", flattenWeight(&resourceRecordSet)); err != nil {
+			return err
+		}
+	}
+
+	if _, ok := d.GetOk("failover_routing_policy"); ok {
+		if err := d.Set("failover_routing_policy", flattenFailover(&resourceRecordSet)); err != nil {
+			return err
+		}
+	}
+
+	if err := d.Set("default_host", resourceRecordSet.XniftyDefaultHost); err != nil {
+		return err
+	}
+
+	if err := d.Set("comment", resourceRecordSet.XniftyComment); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func flattenWeight(record *dns.ResourceRecordSets) []map[string]interface{} {
+	res := map[string]interface{}{}
+
+	if record != nil && record.Weight != nil {
+		res["weight"] = nifcloud.Int64Value(record.Weight)
+	}
+
+	return []map[string]interface{}{res}
+}
+
+func flattenFailover(record *dns.ResourceRecordSets) []map[string]interface{} {
+	res := map[string]interface{}{}
+
+	if record != nil && record.Failover != nil {
+		res["type"] = nifcloud.StringValue(record.Failover)
+		res["health_check"] = flattenHealthCheck(record.XniftyHealthCheckConfig)
+	}
+
+	return []map[string]interface{}{res}
+}
+
+func flattenHealthCheck(healthCheck *dns.XniftyHealthCheckConfig) []map[string]interface{} {
+	res := map[string]interface{}{}
+
+	if healthCheck != nil && healthCheck.Protocol != nil &&
+		healthCheck.IPAddress != nil && healthCheck.Port != nil {
+		res["protocol"] = nifcloud.StringValue(healthCheck.Protocol)
+		res["ip_address"] = nifcloud.StringValue(healthCheck.IPAddress)
+		res["port"] = nifcloud.Int64Value(healthCheck.Port)
+		res["resource_path"] = nifcloud.StringValue(healthCheck.ResourcePath)
+		res["resource_domain"] = nifcloud.StringValue(healthCheck.FullyQualifiedDomainName)
+	}
+
+	return []map[string]interface{}{res}
+}

--- a/nifcloud/resources/dns/record/flattener_test.go
+++ b/nifcloud/resources/dns/record/flattener_test.go
@@ -1,0 +1,121 @@
+package record
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+	"github.com/nifcloud/nifcloud-sdk-go/service/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlatten(t *testing.T) {
+	healthCheck := map[string]interface{}{
+		"protocol":        "HTTP",
+		"ip_address":      "192.0.2.1",
+		"port":            8080,
+		"resource_path":   "test_resource_path",
+		"resource_domain": "test_resource_domain",
+	}
+	rd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{
+		"zone_id": "test_zone_id",
+		"name":    "test_name",
+		"type":    "A",
+		"record":  "192.0.2.1",
+		"ttl":     60,
+		"weighted_routing_policy": []interface{}{map[string]interface{}{
+			"weight": 60,
+		}},
+		"failover_routing_policy": []interface{}{map[string]interface{}{
+			"type":         "PRIMARY",
+			"health_check": []interface{}{healthCheck},
+		}},
+		"default_host":   "test_default_host",
+		"comment":        "test_comment",
+		"set_identifier": "test_set_identifier",
+	})
+	rd.SetId("test_set_identifier")
+
+	wantNotFoundRd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{})
+
+	type args struct {
+		res *dns.ListResourceRecordSetsResponse
+		d   *schema.ResourceData
+	}
+	tests := []struct {
+		name string
+		args args
+		want *schema.ResourceData
+	}{
+		{
+			name: "flattens the response",
+			args: args{
+				d: rd,
+				res: &dns.ListResourceRecordSetsResponse{
+					ListResourceRecordSetsOutput: &dns.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []dns.ResourceRecordSets{
+							{
+								Failover:          nifcloud.String("PRIMARY"),
+								Name:              nifcloud.String("test_name"),
+								SetIdentifier:     nifcloud.String("test_set_identifier"),
+								TTL:               nifcloud.Int64(60),
+								Type:              nifcloud.String("A"),
+								Weight:            nifcloud.Int64(60),
+								XniftyComment:     nifcloud.String("test_comment"),
+								XniftyDefaultHost: nifcloud.String("test_default_host"),
+								ResourceRecords: []dns.ResourceRecords{{
+									Value: nifcloud.String("192.0.2.1"),
+								}},
+								XniftyHealthCheckConfig: &dns.XniftyHealthCheckConfig{
+									FullyQualifiedDomainName: nifcloud.String("test_resource_domain"),
+									IPAddress:                nifcloud.String("192.0.2.1"),
+									Port:                     nifcloud.Int64(8080),
+									Protocol:                 nifcloud.String("HTTP"),
+									ResourcePath:             nifcloud.String("test_resource_path"),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: rd,
+		},
+		{
+			name: "flattens the response even when the resource has been removed externally",
+			args: args{
+				d: wantNotFoundRd,
+				res: &dns.ListResourceRecordSetsResponse{
+					ListResourceRecordSetsOutput: &dns.ListResourceRecordSetsOutput{
+						ResourceRecordSets: []dns.ResourceRecordSets{},
+					},
+				},
+			},
+			want: wantNotFoundRd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := flatten(tt.args.d, tt.args.res)
+			assert.NoError(t, err)
+
+			if tt.args.res == nil {
+				return
+			}
+
+			wantState := tt.want.State()
+			if wantState == nil {
+				tt.want.SetId("some")
+				wantState = tt.want.State()
+			}
+
+			gotState := tt.args.d.State()
+			if gotState == nil {
+				tt.args.d.SetId("some")
+				gotState = tt.args.d.State()
+			}
+
+			assert.Equal(t, wantState.Attributes, gotState.Attributes)
+		})
+	}
+}

--- a/nifcloud/resources/dns/record/helper.go
+++ b/nifcloud/resources/dns/record/helper.go
@@ -1,0 +1,48 @@
+package record
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func validateDnsRecordImportString(importStr string) ([]string, error) {
+	// example: setIdentifier_example.test
+
+	importParts := strings.Split(importStr, "_")
+	errStr := "unexpected format of import string (%q), expected SETIDENTIFIER_ZONEID: %s"
+	if len(importParts) < 2 {
+		return nil, fmt.Errorf(errStr, importStr, "invalid parts")
+	}
+
+	setIdentifier := importParts[0]
+	zoneID := importParts[1]
+
+	if zoneID == "" {
+		return nil, fmt.Errorf(errStr, importStr, "zone_id must be required")
+	}
+
+	if setIdentifier == "" {
+		return nil, fmt.Errorf(errStr, importStr, "set_identifier must be required")
+	}
+
+	return importParts, nil
+}
+
+func populateDnsRecordFromImport(d *schema.ResourceData, importParts []string) error {
+	setIdentifier := importParts[0]
+	zoneID := importParts[1]
+
+	if err := d.Set("set_identifier", setIdentifier); err != nil {
+		return err
+	}
+
+	d.SetId(setIdentifier)
+
+	if err := d.Set("zone_id", zoneID); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/nifcloud/resources/dns/record/read.go
+++ b/nifcloud/resources/dns/record/read.go
@@ -1,0 +1,45 @@
+package record
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws/awserr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
+	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/client"
+)
+
+func read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	input := expandListResourceRecordSets(d)
+	svc := meta.(*client.Client).DNS
+	req := svc.ListResourceRecordSetsRequest(input)
+
+	res, err := req.Send(ctx)
+	if err != nil {
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == "NoSuchHostedZone" {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("failed reading dns record: %s", err))
+	}
+
+	if d.IsNewResource() {
+		for _, s := range res.ResourceRecordSets {
+			for _, r := range s.ResourceRecords {
+				if nifcloud.StringValue(r.Value) == d.Get("record").(string) {
+					d.SetId(nifcloud.StringValue(s.SetIdentifier))
+				}
+			}
+		}
+	}
+
+	if err := flatten(d, res); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/nifcloud/resources/dns/record/schema.go
+++ b/nifcloud/resources/dns/record/schema.go
@@ -1,0 +1,182 @@
+package record
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/validator"
+)
+
+const description = "Provides a dns record resource."
+
+// New returns the nifcloud_dns_record resource schema.
+func New() *schema.Resource {
+	return &schema.Resource{
+		Description: description,
+		Schema:      newSchema(),
+
+		CreateContext: create,
+		ReadContext:   read,
+		DeleteContext: delete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				importParts, err := validateDnsRecordImportString(d.Id())
+				if err != nil {
+					return nil, err
+				}
+				if err := populateDnsRecordFromImport(d, importParts); err != nil {
+					return nil, err
+				}
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(5 * time.Minute),
+		},
+	}
+}
+
+func newSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"zone_id": {
+			Type:        schema.TypeString,
+			Description: "The ID of the hosted zone to contain this record.",
+			Required:    true,
+			ForceNew:    true,
+		},
+		"name": {
+			Type:        schema.TypeString,
+			Description: "The name of the record.",
+			Required:    true,
+			ForceNew:    true,
+		},
+		"type": {
+			Type:        schema.TypeString,
+			Description: "The type of the record.",
+			Required:    true,
+			ForceNew:    true,
+		},
+		"record": {
+			Type:        schema.TypeString,
+			Description: "The value of the record.",
+			Required:    true,
+			ForceNew:    true,
+		},
+		"ttl": {
+			Type:         schema.TypeInt,
+			Description:  "The TTL of the record.",
+			Optional:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IntBetween(60, 86400),
+			Default:      3600,
+		},
+		"weighted_routing_policy": {
+			Type:          schema.TypeList,
+			Description:   "The configs for weighted routing policy. Conflicts with failover_routing_policy.",
+			Optional:      true,
+			ForceNew:      true,
+			MaxItems:      1,
+			ConflictsWith: []string{"failover_routing_policy"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"weight": {
+						Type:        schema.TypeInt,
+						Description: "The record weighted value.",
+						Optional:    true,
+						ForceNew:    true,
+					},
+				},
+			},
+		},
+		"failover_routing_policy": {
+			Type:          schema.TypeList,
+			Description:   "The configs for failover routing policy. Conflicts with weighted_routing_policy.",
+			Optional:      true,
+			ForceNew:      true,
+			MaxItems:      1,
+			ConflictsWith: []string{"weighted_routing_policy"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Type:        schema.TypeString,
+						Description: "The record failover type.",
+						Optional:    true,
+						ForceNew:    true,
+						ValidateFunc: validation.StringInSlice([]string{
+							"PRIMARY", "SECONDARY"}, false),
+					},
+					"health_check": {
+						Type:        schema.TypeList,
+						Description: "The configs for health check if using failover.",
+						Optional:    true,
+						ForceNew:    true,
+						MaxItems:    1,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"protocol": {
+									Type:        schema.TypeString,
+									Description: "The health check protocol.",
+									Optional:    true,
+									ForceNew:    true,
+									ValidateFunc: validation.StringInSlice([]string{
+										"HTTP", "HTTPS", "TCP"}, false),
+								},
+								"ip_address": {
+									Type:             schema.TypeString,
+									Description:      "The health check IP address.",
+									Optional:         true,
+									ForceNew:         true,
+									ValidateDiagFunc: validator.StringRuneCountBetween(1, 32),
+								},
+								"port": {
+									Type:         schema.TypeInt,
+									Description:  "The health check port.",
+									Optional:     true,
+									ForceNew:     true,
+									ValidateFunc: validation.IntBetween(1, 65535),
+								},
+								"resource_path": {
+									Type:             schema.TypeString,
+									Description:      "The health check resource path if using HTTP or HTTPS protocol.",
+									Optional:         true,
+									ForceNew:         true,
+									ValidateDiagFunc: validator.StringRuneCountBetween(0, 255),
+								},
+								"resource_domain": {
+									Type:             schema.TypeString,
+									Description:      "The health check resource domain if using HTTP or HTTPS protocol.",
+									Optional:         true,
+									ForceNew:         true,
+									ValidateDiagFunc: validator.StringRuneCountBetween(0, 255),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"default_host": {
+			Type:        schema.TypeString,
+			Description: "The default host if using LBR.",
+			Optional:    true,
+			ForceNew:    true,
+		},
+		"comment": {
+			Type:             schema.TypeString,
+			Description:      "The comment of the record.",
+			Optional:         true,
+			ForceNew:         true,
+			ValidateDiagFunc: validator.StringRuneCountBetween(0, 255),
+		},
+		"set_identifier": {
+			Type:        schema.TypeString,
+			Description: "The unique identifier to differentiate records with routing policies from one another.",
+			Optional:    true,
+			Computed:    true,
+			ForceNew:    true,
+		},
+	}
+}


### PR DESCRIPTION
## Description

- Add nifcloud_dns_record resource.

## How Has This Been Tested?

- [ ]  Buld with `make install` command, and Apply example.

```:console
make install
cd examples/dns_zone
terraform init -plugin-dir ~/.terraform.d/plugins
terraform plan
terraform apply
```
※change example domain to test domain

- [ ] Run acceptance tests.

```:console
export TF_VAR_dns_zone_name=${test_domain}
export TF_VAR_dns_record_name=${test_domain_record}
TF_ACC=1 go test ./nifcloud/acc/... -v -count 1 -parallel 20 -timeout 360m -run TestAcc_DnsRec
ord_Weight
TF_ACC=1 go test ./nifcloud/acc/... -v -count 1 -parallel 20 -timeout 360m -run TestAcc_DnsRec
ord_Failover
```

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation