### PR TITLE
Change behaviour of dns record flattener

### DIFF
--- a/examples/dns_record/main.tf
+++ b/examples/dns_record/main.tf
@@ -11,7 +11,7 @@ resource "nifcloud_dns_record" "example" {
   name    = "test.example.test"
   type    = "A"
   ttl     = 300
-  record  = ["192.168.0.1"]
+  record  = "192.168.0.1"
   comment = "memo"
 }
 
@@ -19,4 +19,3 @@ resource "nifcloud_dns_zone" "example" {
   name    = "example.test"
   comment = "memo"
 }
-

--- a/nifcloud/acc/dns_record_test.go
+++ b/nifcloud/acc/dns_record_test.go
@@ -41,6 +41,7 @@ func TestAcc_DnsRecord_AtSignAsName(t *testing.T) {
 				Config: testAccDnsRecord(t, "testdata/dns_record_name.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsRecordExists(resourceName, &record),
+					testAccCheckDnsRecordNameValues(&record),
 					resource.TestCheckResourceAttr(resourceName, "zone_id", dnsZoneName),
 					resource.TestCheckResourceAttr(resourceName, "name", "@"),
 					resource.TestCheckResourceAttr(resourceName, "type", "A"),
@@ -174,6 +175,32 @@ func testAccCheckDnsRecordExists(n string, dnsRecord *types.ResourceRecordSets) 
 		}
 
 		*dnsRecord = foundDnsRecord
+		return nil
+	}
+}
+
+func testAccCheckDnsRecordNameValues(dnsRecord *types.ResourceRecordSets) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if nifcloud.ToString(dnsRecord.Name) != dnsZoneName {
+			return fmt.Errorf("bad name state, expected %s, got: %#v", dnsZoneName, dnsRecord.Name)
+		}
+
+		if nifcloud.ToString(dnsRecord.Type) != "A" {
+			return fmt.Errorf("bad type state, expected \"A\", got: %#v", dnsRecord.Type)
+		}
+
+		if nifcloud.ToInt32(dnsRecord.TTL) != 60 {
+			return fmt.Errorf("bad ttl state, expected 60, got: %#v", dnsRecord.TTL)
+		}
+
+		if nifcloud.ToString(dnsRecord.ResourceRecords[0].Value) != "192.0.2.1" {
+			return fmt.Errorf("bad resource_records.0.value state, expected \"192.0.2.1\", got: %#v", dnsRecord.ResourceRecords[0].Value)
+		}
+
+		if nifcloud.ToString(dnsRecord.XniftyComment) != "tfacc-memo" {
+			return fmt.Errorf("bad x_nifty_comment state, expected \"tfacc-memo\", got: %#v", dnsRecord.XniftyComment)
+		}
+
 		return nil
 	}
 }

--- a/nifcloud/acc/dns_record_test.go
+++ b/nifcloud/acc/dns_record_test.go
@@ -27,6 +27,38 @@ func init() {
 	})
 }
 
+func TestAcc_DnsRecord_AtSignAsName(t *testing.T) {
+	var record types.ResourceRecordSets
+
+	resourceName := "nifcloud_dns_record.basic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDnsRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecord(t, "testdata/dns_record_name.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordExists(resourceName, &record),
+					resource.TestCheckResourceAttr(resourceName, "zone_id", dnsZoneName),
+					resource.TestCheckResourceAttr(resourceName, "name", "@"),
+					resource.TestCheckResourceAttr(resourceName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "60"),
+					resource.TestCheckResourceAttr(resourceName, "record", "192.0.2.1"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "tfacc-memo"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccDnsRecordImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAcc_DnsRecord_Weight(t *testing.T) {
 	var record types.ResourceRecordSets
 

--- a/nifcloud/acc/testdata/dns_record_name.tf
+++ b/nifcloud/acc/testdata/dns_record_name.tf
@@ -1,0 +1,18 @@
+resource "nifcloud_dns_record" "basic" {
+  zone_id        = nifcloud_dns_zone.basic.id
+  name           = "@"
+  type           = "A"
+  ttl            = 60
+  record         = "192.0.2.1"
+  comment        = "tfacc-memo"
+}
+
+resource "nifcloud_dns_zone" "basic" {
+  name    = var.dns_zone_name
+  comment = "tfacc-memo"
+}
+
+variable "dns_zone_name" {
+    description = "test dns zone"
+    type        = string
+}

--- a/nifcloud/resources/dns/record/flattener.go
+++ b/nifcloud/resources/dns/record/flattener.go
@@ -31,7 +31,7 @@ func flatten(d *schema.ResourceData, res *dns.ListResourceRecordSetsOutput) erro
 		return err
 	}
 
-	if err := d.Set("name", resourceRecordSet.Name); err != nil {
+	if err := d.Set("name", flattenName(d, &resourceRecordSet)); err != nil {
 		return err
 	}
 
@@ -68,6 +68,13 @@ func flatten(d *schema.ResourceData, res *dns.ListResourceRecordSetsOutput) erro
 	}
 
 	return nil
+}
+
+func flattenName(d *schema.ResourceData, record *types.ResourceRecordSets) interface{} {
+	if *record.Name == d.Get("zone_id") {
+		return "@"
+	}
+	return record.Name
 }
 
 func flattenWeight(record *types.ResourceRecordSets) []map[string]interface{} {

--- a/nifcloud/resources/dns/record/flattener_test.go
+++ b/nifcloud/resources/dns/record/flattener_test.go
@@ -18,7 +18,7 @@ func TestFlatten(t *testing.T) {
 		"resource_path":   "test_resource_path",
 		"resource_domain": "test_resource_domain",
 	}
-	rd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{
+	raw := map[string]interface{}{
 		"zone_id": "test_zone_id",
 		"name":    "test_name",
 		"type":    "A",
@@ -34,9 +34,13 @@ func TestFlatten(t *testing.T) {
 		"default_host":   "test_default_host",
 		"comment":        "test_comment",
 		"set_identifier": "test_set_identifier",
-	})
+	}
+	rd := schema.TestResourceDataRaw(t, newSchema(), raw)
 	rd.SetId("test_set_identifier")
+	wantRd := schema.TestResourceDataRaw(t, newSchema(), raw)
+	wantRd.SetId("test_set_identifier")
 
+	notFoundRd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{})
 	wantNotFoundRd := schema.TestResourceDataRaw(t, newSchema(), map[string]interface{}{})
 
 	type args struct {
@@ -77,12 +81,12 @@ func TestFlatten(t *testing.T) {
 					},
 				},
 			},
-			want: rd,
+			want: wantRd,
 		},
 		{
 			name: "flattens the response even when the resource has been removed externally",
 			args: args{
-				d: wantNotFoundRd,
+				d: notFoundRd,
 				res: &dns.ListResourceRecordSetsOutput{
 					ResourceRecordSets: []types.ResourceRecordSets{},
 				},
@@ -111,7 +115,6 @@ func TestFlatten(t *testing.T) {
 				tt.args.d.SetId("some")
 				gotState = tt.args.d.State()
 			}
-
 			assert.Equal(t, wantState.Attributes, gotState.Attributes)
 		})
 	}


### PR DESCRIPTION
## Summary

* Resolve #111
* In the case `@` is set as the name of `nifcloud_dns_record` nifcloud DNS API returns the zone name as its record name.
* This p-r changes the behaviour of the provider for `@` to be saved in tf state so that terraform can properly compare.

## Test

* [x] Run `TestAcc_DnsRecord_AtSignAsName` test and enjoi :yoshi: