### PR TITLE
Support dns record name shorthand

### DIFF
--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -80,8 +80,8 @@ In addition to the arguments listed above, the following computed attributes are
 
 ## Import
 
-nifcloud_dns_record can be imported using the `set_identifier`, `zone_id`.
-separated by underscores ( _ ). All parts are required.
+nifcloud_dns_record can be imported using the `set_identifier`, `zone_id` and `name`.
+separated by underscores ( _ ). All parts are required. `name` should be matched with the value of `name` in tf files.
 
 ```
 $ terraform import nifcloud_dns_record.example XXXXXXXXX_example.test

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -84,5 +84,5 @@ nifcloud_dns_record can be imported using the `set_identifier`, `zone_id` and `n
 separated by underscores ( _ ). All parts are required. `name` should be matched with the value of `name` in tf files.
 
 ```
-$ terraform import nifcloud_dns_record.example XXXXXXXXX_example.test
+$ terraform import nifcloud_dns_record.example XXXXXXXXX_example.test_@
 ```

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -84,5 +84,5 @@ nifcloud_dns_record can be imported using the `set_identifier`, `zone_id` and `n
 separated by underscores ( _ ). All parts are required. `name` should be matched with the value of `name` in tf files.
 
 ```
-$ terraform import nifcloud_dns_record.example XXXXXXXXX_example.test_@
+$ terraform import nifcloud_dns_record.example XXXXXXXXX_example.test_test.example.test
 ```

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -20,12 +20,30 @@ terraform {
   }
 }
 
-resource "nifcloud_dns_record" "example" {
+resource "nifcloud_dns_record" "example1" {
   zone_id = nifcloud_dns_zone.example.id
-  name    = "test.example.test"
+  name    = "test1"
   type    = "A"
   ttl     = 300
   record  = "192.168.0.1"
+  comment = "memo"
+}
+
+resource "nifcloud_dns_record" "example2" {
+  zone_id = nifcloud_dns_zone.example.id
+  name    = "test2.example.test"
+  type    = "A"
+  ttl     = 300
+  record  = "192.168.0.2"
+  comment = "memo"
+}
+
+resource "nifcloud_dns_record" "example3" {
+  zone_id = nifcloud_dns_zone.example.id
+  name    = "@"
+  type    = "A"
+  ttl     = 300
+  record  = "192.168.0.3"
   comment = "memo"
 }
 

--- a/examples/dns_record/main.tf
+++ b/examples/dns_record/main.tf
@@ -6,12 +6,30 @@ terraform {
   }
 }
 
-resource "nifcloud_dns_record" "example" {
+resource "nifcloud_dns_record" "example1" {
   zone_id = nifcloud_dns_zone.example.id
-  name    = "test.example.test"
+  name    = "test1"
   type    = "A"
   ttl     = 300
   record  = "192.168.0.1"
+  comment = "memo"
+}
+
+resource "nifcloud_dns_record" "example2" {
+  zone_id = nifcloud_dns_zone.example.id
+  name    = "test2.example.test"
+  type    = "A"
+  ttl     = 300
+  record  = "192.168.0.2"
+  comment = "memo"
+}
+
+resource "nifcloud_dns_record" "example3" {
+  zone_id = nifcloud_dns_zone.example.id
+  name    = "@"
+  type    = "A"
+  ttl     = 300
+  record  = "192.168.0.3"
   comment = "memo"
 }
 

--- a/nifcloud/acc/dns_record_test.go
+++ b/nifcloud/acc/dns_record_test.go
@@ -75,12 +75,12 @@ func TestAcc_DnsRecord_ShorthandName(t *testing.T) {
 				Config: testAccDnsRecord(t, "testdata/dns_record_shorthand_name.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsRecordExists(resourceName, &record),
-					testAccCheckDnsRecordNameValues(&record),
+					testAccCheckDnsRecordNameValuesWhenRequestedWithShorthandName(&record),
 					resource.TestCheckResourceAttr(resourceName, "zone_id", dnsZoneName),
 					resource.TestCheckResourceAttr(resourceName, "name", dnsRecordShorthandName),
-					resource.TestCheckResourceAttr(resourceName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "type", "TXT"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "60"),
-					resource.TestCheckResourceAttr(resourceName, "record", "192.0.2.1"),
+					resource.TestCheckResourceAttr(resourceName, "record", "tfacc"),
 					resource.TestCheckResourceAttr(resourceName, "comment", "tfacc-memo"),
 				),
 			},
@@ -239,22 +239,23 @@ func testAccCheckDnsRecordZoneIdAsNameValues(dnsRecord *types.ResourceRecordSets
 	}
 }
 
-func testAccCheckDnsRecordNameValues(dnsRecord *types.ResourceRecordSets) resource.TestCheckFunc {
+func testAccCheckDnsRecordNameValuesWhenRequestedWithShorthandName(dnsRecord *types.ResourceRecordSets) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if nifcloud.ToString(dnsRecord.Name) != dnsRecordName {
-			return fmt.Errorf("bad name state, expected %s, got: %#v", dnsRecordName, dnsRecord.Name)
+		expectedDnsRecordName := fmt.Sprintf("%s.%s", dnsRecordShorthandName, dnsZoneName)
+		if nifcloud.ToString(dnsRecord.Name) != expectedDnsRecordName {
+			return fmt.Errorf("bad name state, expected %s, got: %#v", expectedDnsRecordName, dnsRecord.Name)
 		}
 
-		if nifcloud.ToString(dnsRecord.Type) != "A" {
-			return fmt.Errorf("bad type state, expected \"A\", got: %#v", dnsRecord.Type)
+		if nifcloud.ToString(dnsRecord.Type) != "TXT" {
+			return fmt.Errorf("bad type state, expected \"TXT\", got: %#v", dnsRecord.Type)
 		}
 
 		if nifcloud.ToInt32(dnsRecord.TTL) != 60 {
 			return fmt.Errorf("bad ttl state, expected 60, got: %#v", dnsRecord.TTL)
 		}
 
-		if nifcloud.ToString(dnsRecord.ResourceRecords[0].Value) != "192.0.2.1" {
-			return fmt.Errorf("bad resource_records.0.value state, expected \"192.0.2.1\", got: %#v", dnsRecord.ResourceRecords[0].Value)
+		if nifcloud.ToString(dnsRecord.ResourceRecords[0].Value) != "tfacc" {
+			return fmt.Errorf("bad resource_records.0.value state, expected \"tfacc\", got: %#v", dnsRecord.ResourceRecords[0].Value)
 		}
 
 		if nifcloud.ToString(dnsRecord.XniftyComment) != "tfacc-memo" {

--- a/nifcloud/acc/dns_record_test.go
+++ b/nifcloud/acc/dns_record_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 var dnsRecordName = os.Getenv("TF_VAR_dns_record_name")
+var dnsRecordShorthandName = os.Getenv("TF_VAR_dns_record_shorthand_name")
 
 func init() {
 	resource.AddTestSweepers("nifcloud_dns_record", &resource.Sweeper{
@@ -41,9 +42,42 @@ func TestAcc_DnsRecord_AtSignAsName(t *testing.T) {
 				Config: testAccDnsRecord(t, "testdata/dns_record_name.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDnsRecordExists(resourceName, &record),
-					testAccCheckDnsRecordNameValues(&record),
+					testAccCheckDnsRecordZoneIdAsNameValues(&record),
 					resource.TestCheckResourceAttr(resourceName, "zone_id", dnsZoneName),
 					resource.TestCheckResourceAttr(resourceName, "name", "@"),
+					resource.TestCheckResourceAttr(resourceName, "type", "A"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "60"),
+					resource.TestCheckResourceAttr(resourceName, "record", "192.0.2.1"),
+					resource.TestCheckResourceAttr(resourceName, "comment", "tfacc-memo"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccDnsRecordImportStateIDFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAcc_DnsRecord_ShorthandName(t *testing.T) {
+	var record types.ResourceRecordSets
+
+	resourceName := "nifcloud_dns_record.basic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactory,
+		CheckDestroy:      testAccDnsRecordResourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecord(t, "testdata/dns_record_shorthand_name.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsRecordExists(resourceName, &record),
+					testAccCheckDnsRecordNameValues(&record),
+					resource.TestCheckResourceAttr(resourceName, "zone_id", dnsZoneName),
+					resource.TestCheckResourceAttr(resourceName, "name", dnsRecordShorthandName),
 					resource.TestCheckResourceAttr(resourceName, "type", "A"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "60"),
 					resource.TestCheckResourceAttr(resourceName, "record", "192.0.2.1"),
@@ -179,10 +213,36 @@ func testAccCheckDnsRecordExists(n string, dnsRecord *types.ResourceRecordSets) 
 	}
 }
 
-func testAccCheckDnsRecordNameValues(dnsRecord *types.ResourceRecordSets) resource.TestCheckFunc {
+func testAccCheckDnsRecordZoneIdAsNameValues(dnsRecord *types.ResourceRecordSets) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if nifcloud.ToString(dnsRecord.Name) != dnsZoneName {
 			return fmt.Errorf("bad name state, expected %s, got: %#v", dnsZoneName, dnsRecord.Name)
+		}
+
+		if nifcloud.ToString(dnsRecord.Type) != "A" {
+			return fmt.Errorf("bad type state, expected \"A\", got: %#v", dnsRecord.Type)
+		}
+
+		if nifcloud.ToInt32(dnsRecord.TTL) != 60 {
+			return fmt.Errorf("bad ttl state, expected 60, got: %#v", dnsRecord.TTL)
+		}
+
+		if nifcloud.ToString(dnsRecord.ResourceRecords[0].Value) != "192.0.2.1" {
+			return fmt.Errorf("bad resource_records.0.value state, expected \"192.0.2.1\", got: %#v", dnsRecord.ResourceRecords[0].Value)
+		}
+
+		if nifcloud.ToString(dnsRecord.XniftyComment) != "tfacc-memo" {
+			return fmt.Errorf("bad x_nifty_comment state, expected \"tfacc-memo\", got: %#v", dnsRecord.XniftyComment)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDnsRecordNameValues(dnsRecord *types.ResourceRecordSets) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if nifcloud.ToString(dnsRecord.Name) != dnsRecordName {
+			return fmt.Errorf("bad name state, expected %s, got: %#v", dnsRecordName, dnsRecord.Name)
 		}
 
 		if nifcloud.ToString(dnsRecord.Type) != "A" {
@@ -368,10 +428,12 @@ func testAccDnsRecordImportStateIDFunc(resourceName string) resource.ImportState
 
 		setIdentifier := rs.Primary.Attributes["set_identifier"]
 		zoneId := rs.Primary.Attributes["zone_id"]
+		name := rs.Primary.Attributes["name"]
 
 		var parts []string
 		parts = append(parts, setIdentifier)
 		parts = append(parts, zoneId)
+		parts = append(parts, name)
 
 		id := strings.Join(parts, "_")
 		return id, nil

--- a/nifcloud/acc/testdata/dns_record_shorthand_name.tf
+++ b/nifcloud/acc/testdata/dns_record_shorthand_name.tf
@@ -1,9 +1,9 @@
 resource "nifcloud_dns_record" "basic" {
   zone_id        = nifcloud_dns_zone.basic.id
   name           = var.dns_record_shorthand_name
-  type           = "A"
+  type           = "TXT"
   ttl            = 60
-  record         = "192.0.2.1"
+  record         = "tfacc"
   comment        = "tfacc-memo"
 }
 

--- a/nifcloud/acc/testdata/dns_record_shorthand_name.tf
+++ b/nifcloud/acc/testdata/dns_record_shorthand_name.tf
@@ -1,0 +1,23 @@
+resource "nifcloud_dns_record" "basic" {
+  zone_id        = nifcloud_dns_zone.basic.id
+  name           = var.dns_record_shorthand_name
+  type           = "A"
+  ttl            = 60
+  record         = "192.0.2.1"
+  comment        = "tfacc-memo"
+}
+
+resource "nifcloud_dns_zone" "basic" {
+  name    = var.dns_zone_name
+  comment = "tfacc-memo"
+}
+
+variable "dns_record_shorthand_name" {
+    description = "test dns record (shorthand)"
+    type        = string
+}
+
+variable "dns_zone_name" {
+    description = "test dns zone"
+    type        = string
+}

--- a/nifcloud/resources/dns/record/flattener.go
+++ b/nifcloud/resources/dns/record/flattener.go
@@ -74,6 +74,9 @@ func flattenName(d *schema.ResourceData, record *types.ResourceRecordSets) inter
 	if *record.Name == d.Get("zone_id") {
 		return "@"
 	}
+	if *record.Name == fmt.Sprintf("%s.%s", d.Get("name"), d.Get("zone_id")) {
+		return d.Get("name")
+	}
 	return record.Name
 }
 

--- a/nifcloud/resources/dns/record/flattener_test.go
+++ b/nifcloud/resources/dns/record/flattener_test.go
@@ -137,6 +137,37 @@ func TestFlatten(t *testing.T) {
 			want: wantRdWithAtSignAsName,
 		},
 		{
+			name: "flattens the response when we requested with shorthand name",
+			args: args{
+				d: rd,
+				res: &dns.ListResourceRecordSetsOutput{
+					ResourceRecordSets: []types.ResourceRecordSets{
+						{
+							Failover:          nifcloud.String("PRIMARY"),
+							Name:              nifcloud.String("test_name.test_zone_id"),
+							SetIdentifier:     nifcloud.String("test_set_identifier"),
+							TTL:               nifcloud.Int32(60),
+							Type:              nifcloud.String("A"),
+							Weight:            nifcloud.Int32(60),
+							XniftyComment:     nifcloud.String("test_comment"),
+							XniftyDefaultHost: nifcloud.String("test_default_host"),
+							ResourceRecords: []types.ResourceRecords{{
+								Value: nifcloud.String("192.0.2.1"),
+							}},
+							XniftyHealthCheckConfig: &types.XniftyHealthCheckConfig{
+								FullyQualifiedDomainName: nifcloud.String("test_resource_domain"),
+								IPAddress:                nifcloud.String("192.0.2.1"),
+								Port:                     nifcloud.Int32(8080),
+								Protocol:                 nifcloud.String("HTTP"),
+								ResourcePath:             nifcloud.String("test_resource_path"),
+							},
+						},
+					},
+				},
+			},
+			want: wantRd,
+		},
+		{
 			name: "flattens the response even when the resource has been removed externally",
 			args: args{
 				d: notFoundRd,

--- a/nifcloud/resources/dns/record/helper.go
+++ b/nifcloud/resources/dns/record/helper.go
@@ -8,16 +8,23 @@ import (
 )
 
 func validateDnsRecordImportString(importStr string) ([]string, error) {
-	// example: setIdentifier_example.test
+	// example: setIdentifier_example.test_@
+	// example: setIdentifier_example.test_sub
+	// example: setIdentifier_example.test_sub.example.test
 
 	importParts := strings.Split(importStr, "_")
-	errStr := "unexpected format of import string (%q), expected SETIDENTIFIER_ZONEID: %s"
-	if len(importParts) < 2 {
+	errStr := "unexpected format of import string (%q), expected SETIDENTIFIER_ZONEID_NAME: %s"
+	if len(importParts) < 3 {
 		return nil, fmt.Errorf(errStr, importStr, "invalid parts")
 	}
 
 	setIdentifier := importParts[0]
 	zoneID := importParts[1]
+	name := importParts[2]
+
+	if name == "" {
+		return nil, fmt.Errorf(errStr, importStr, "name must be required")
+	}
 
 	if zoneID == "" {
 		return nil, fmt.Errorf(errStr, importStr, "zone_id must be required")
@@ -33,6 +40,7 @@ func validateDnsRecordImportString(importStr string) ([]string, error) {
 func populateDnsRecordFromImport(d *schema.ResourceData, importParts []string) error {
 	setIdentifier := importParts[0]
 	zoneID := importParts[1]
+	name := importParts[2]
 
 	if err := d.Set("set_identifier", setIdentifier); err != nil {
 		return err
@@ -41,6 +49,10 @@ func populateDnsRecordFromImport(d *schema.ResourceData, importParts []string) e
 	d.SetId(setIdentifier)
 
 	if err := d.Set("zone_id", zoneID); err != nil {
+		return err
+	}
+
+	if err := d.Set("name", name); err != nil {
 		return err
 	}
 

--- a/nifcloud/resources/dns/record/helper.go
+++ b/nifcloud/resources/dns/record/helper.go
@@ -40,7 +40,7 @@ func validateDnsRecordImportString(importStr string) ([]string, error) {
 func populateDnsRecordFromImport(d *schema.ResourceData, importParts []string) error {
 	setIdentifier := importParts[0]
 	zoneID := importParts[1]
-	name := importParts[2]
+	name := strings.Join(importParts[2:], "_")
 
 	if err := d.Set("set_identifier", setIdentifier); err != nil {
 		return err


### PR DESCRIPTION
## Summary

NIFCLOUD API supports shorthand for dns record name. For example, if the dns zone is `example.com` and we request with `test` as name, the name field of the response will be `test.example.com`. Currently, planning after applying with shorthand name shows differences from the current state though there is no difference.

This p-r fixes the flattener and helper so that the 2nd planning does not generate differences. In addition, the import command argument will change with this p-r. It is required to support the shorthand name with import.

## Rejected Ideas

The alternative idea to support the shorthand name is to use [customdiff](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/helper/customdiff). This cannot be used because [ResourceDiff](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk@v1.17.2/helper/schema#ResourceDiff) does not support saving changes except `ForceNew`.

## Review

* Acceptance tests succeed

I manually tested below:

* Apply A/AAAA/NS/CNAME/TXT records and plan without conflicts
* Import A/AAAA/NS/CNAME/TXT records and plan without conflicts