### PR TITLE
Fix doc of load_balancer#import

### DIFF
--- a/docs/resources/load_balancer.md
+++ b/docs/resources/load_balancer.md
@@ -71,7 +71,8 @@ In addition to the arguments listed above, the following computed attributes are
 
 ## Import
 
-nifcloud_load_balancer can be imported using the `parameter corresponding to LBNAME_LBPORT_INSTANCEPORT`, e.g.
+nifcloud_load_balancer can be imported using the `load_balancer_name`, `load_balancer_port` , `instance_port`.
+separated by underscores ( `_` ). All parts are required.
 
 ```
 $ terraform import nifcloud_load_balancer.example example_8000_8000

--- a/docs/resources/load_balancer.md
+++ b/docs/resources/load_balancer.md
@@ -71,8 +71,8 @@ In addition to the arguments listed above, the following computed attributes are
 
 ## Import
 
-nifcloud_load_balancer can be imported using the `parameter corresponding to id`, e.g.
+nifcloud_load_balancer can be imported using the `parameter corresponding to LBNAME_LBPORT_INSTANCEPORT`, e.g.
 
 ```
-$ terraform import nifcloud_load_balancer.example foo
+$ terraform import nifcloud_load_balancer.example example_8000_8000
 ```

--- a/docs/resources/load_balancer_listener.md
+++ b/docs/resources/load_balancer_listener.md
@@ -72,8 +72,9 @@ In addition to the arguments listed above, the following computed attributes are
 
 ## Import
 
-nifcloud_load_balancer_listener can be imported using the `parameter corresponding to id`, e.g.
+nifcloud_load_balancer_listener can be imported using the `load_balancer_name`, `load_balancer_port` , `instance_port`.
+separated by underscores ( `_` ). All parts are required.
 
 ```
-$ terraform import nifcloud_load_balancer_listener.example foo
+$ terraform import nifcloud_load_balancer_listener.example example_8000_8000
 ```


### PR DESCRIPTION
## Summary

- I tried to nifcloud_load_balancer import using id, but got an error.
- Shouldn't this use `LBNAME_LBPORT_INSTANCEPORT` instead of `id` ?
  - FYI: https://github.com/nifcloud/terraform-provider-nifcloud/blob/e50ae6323cb0e24be8c573b2ad1412211be43ef2/nifcloud/resources/network/loadbalancer/helper.go#L15

## Current Behavior

```
$ cat terraform.tfstate
{
  ...
      "type": "nifcloud_load_balancer",
      "name": "l4lb",
      ...
            "id": "l4lb",
      ...
$ rm terraform.tfstate
$ terraform import nifcloud_load_balancer.l4lb l4lb
nifcloud_load_balancer.l4lb: Importing from ID "l4lb"...
╷
│ Error: unexpected format of import string ("l4lb"), expected LBNAME_LBPORT_INSTANCEPORT: invalid parts

$ terraform import nifcloud_load_balancer.l4lb l4lb_80_80
nifcloud_load_balancer.l4lb: Importing from ID "l4lb_80_80"...
nifcloud_load_balancer.l4lb: Import prepared!
  Prepared nifcloud_load_balancer for import
nifcloud_load_balancer.l4lb: Refreshing state... [id=l4lb]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```