### PR TITLE
Fix/lint errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - goimports
     - gofmt
@@ -11,10 +10,8 @@ linters:
     - ineffassign
     - misspell
     - staticcheck
-    - structcheck
     - unconvert
     - unused
-    - varcheck
     - vet
 
 run:

--- a/nifcloud/acc/customer_gateway_test.go
+++ b/nifcloud/acc/customer_gateway_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -76,7 +76,7 @@ func TestAcc_CustomerGateway(t *testing.T) {
 }
 
 func testAccCustomerGateway(t *testing.T, fileName string, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/db_instance_test.go
+++ b/nifcloud/acc/db_instance_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -134,7 +134,7 @@ func TestAcc_DBInstance(t *testing.T) {
 }
 
 func testAccDBInstance(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/db_parameter_group_test.go
+++ b/nifcloud/acc/db_parameter_group_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -83,7 +83,7 @@ func TestAcc_DBParameterGroup(t *testing.T) {
 }
 
 func testAccDBParameterGroup(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/db_security_group_test.go
+++ b/nifcloud/acc/db_security_group_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -74,7 +74,7 @@ func TestAcc_DbSecurityGroup(t *testing.T) {
 }
 
 func testAccDbSecurityGroup(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/dhcp_config_test.go
+++ b/nifcloud/acc/dhcp_config_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/aws/smithy-go"
@@ -69,7 +69,7 @@ func TestAcc_DhcpConfig(t *testing.T) {
 }
 
 func testAccDhcpConfig(t *testing.T, fileName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/dhcp_option_test.go
+++ b/nifcloud/acc/dhcp_option_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -65,7 +65,7 @@ func TestAcc_DhcpOption(t *testing.T) {
 }
 
 func testAccDhcpOption(t *testing.T, fileName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/dns_record_test.go
+++ b/nifcloud/acc/dns_record_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -174,7 +173,7 @@ func TestAcc_DnsRecord_Failover(t *testing.T) {
 }
 
 func testAccDnsRecord(t *testing.T, fileName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/dns_zone_test.go
+++ b/nifcloud/acc/dns_zone_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -59,7 +58,7 @@ func TestAcc_DnsZone(t *testing.T) {
 }
 
 func testAccDnsZone(t *testing.T, fileName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/elastic_ip_test.go
+++ b/nifcloud/acc/elastic_ip_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -70,7 +70,7 @@ func TestAcc_ElasticIP(t *testing.T) {
 }
 
 func testAccElasticIP(t *testing.T, fileName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/elb_listener_test.go
+++ b/nifcloud/acc/elb_listener_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -95,7 +95,7 @@ func TestAcc_ELBListener(t *testing.T) {
 }
 
 func testAccELBListener(t *testing.T, fileName, rName, certificate, key, ca string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/elb_test.go
+++ b/nifcloud/acc/elb_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -142,7 +142,7 @@ func TestAcc_ELB(t *testing.T) {
 }
 
 func testAccELB(t *testing.T, fileName, rName, certificate, key, ca string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/ess_domain_dkim_test.go
+++ b/nifcloud/acc/ess_domain_dkim_test.go
@@ -3,7 +3,7 @@ package acc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -47,7 +47,7 @@ func TestAcc_ESSDomainDkim(t *testing.T) {
 }
 
 func testAccESSDomainDkim(t *testing.T, fileName, domain string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/ess_domain_identity_test.go
+++ b/nifcloud/acc/ess_domain_identity_test.go
@@ -3,7 +3,7 @@ package acc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -55,7 +55,7 @@ func TestAcc_ESSDomain(t *testing.T) {
 }
 
 func testAccESSDomain(t *testing.T, fileName, domain string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/ess_email_identity_test.go
+++ b/nifcloud/acc/ess_email_identity_test.go
@@ -3,7 +3,7 @@ package acc
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -55,7 +55,7 @@ func TestAcc_ESSEmail(t *testing.T) {
 }
 
 func testAccESSEmail(t *testing.T, fileName, email string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/hatoba_firewall_group_test.go
+++ b/nifcloud/acc/hatoba_firewall_group_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -69,7 +69,7 @@ func TestAcc_HatobaFirewallGroup(t *testing.T) {
 }
 
 func testAccHatobaFirewallGroup(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/image_test.go
+++ b/nifcloud/acc/image_test.go
@@ -2,7 +2,7 @@ package acc
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -31,7 +31,7 @@ func TestAccDatasourceImage_basic(t *testing.T) {
 }
 
 func testAccImageDataSource(t *testing.T, fileName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/instance_test.go
+++ b/nifcloud/acc/instance_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -139,7 +139,7 @@ func TestAcc_Instance_windows(t *testing.T) {
 }
 
 func testAccInstance(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func testAccInstance(t *testing.T, fileName, rName string) string {
 }
 
 func testAccInstanceWindows(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/key_pair_test.go
+++ b/nifcloud/acc/key_pair_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -70,7 +70,7 @@ func TestAcc_KeyPair(t *testing.T) {
 }
 
 func testAccKeyPair(t *testing.T, fileName, keyName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/load_balancer_listener_test.go
+++ b/nifcloud/acc/load_balancer_listener_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"testing"
 
@@ -103,7 +103,7 @@ func TestAcc_LoadBalancerListener(t *testing.T) {
 }
 
 func testAccLoadBalancerListener(t *testing.T, fileName, rName, instanceName, sshKey, certificate, key, ca string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/load_balancer_test.go
+++ b/nifcloud/acc/load_balancer_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -107,7 +107,7 @@ func TestAcc_LoadBalancer(t *testing.T) {
 }
 
 func testAccLoadBalancer(t *testing.T, fileName, rName, instanceName, sshKey, certificate, key, ca string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/nas_instance_test.go
+++ b/nifcloud/acc/nas_instance_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -141,7 +141,7 @@ func TestAcc_NASInstance_CIFS(t *testing.T) {
 }
 
 func testAccNASInstanceForNFS(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func testAccNASInstanceForNFS(t *testing.T, fileName, rName string) string {
 }
 
 func testAccNASInstanceForCIFS(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/nas_security_group_test.go
+++ b/nifcloud/acc/nas_security_group_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -73,7 +73,7 @@ func TestAcc_NASSecurityGroup(t *testing.T) {
 }
 
 func testAccNASSecurityGroup(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/nat_table_test.go
+++ b/nifcloud/acc/nat_table_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/aws/smithy-go"
@@ -84,7 +84,7 @@ func TestAcc_NatTable(t *testing.T) {
 }
 
 func testAccNatTable(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/network_interface_test.go
+++ b/nifcloud/acc/network_interface_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -76,7 +76,7 @@ func TestAcc_NetworkInterface(t *testing.T) {
 }
 
 func testAccNetworkInterface(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/private_lan_test.go
+++ b/nifcloud/acc/private_lan_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -74,7 +74,7 @@ func TestAcc_PrivateLan(t *testing.T) {
 }
 
 func testAccPrivateLan(t *testing.T, fileName string, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/route_table_test.go
+++ b/nifcloud/acc/route_table_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/aws/smithy-go"
@@ -73,7 +73,7 @@ func TestAcc_RouteTable(t *testing.T) {
 }
 
 func testAccRouteTable(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/router_test.go
+++ b/nifcloud/acc/router_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -90,7 +90,7 @@ func TestAcc_Router(t *testing.T) {
 }
 
 func testAccRouter(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/security_group_rule_test.go
+++ b/nifcloud/acc/security_group_rule_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -119,7 +119,7 @@ func TestAcc_SecurityGroupRule_Source(t *testing.T) {
 }
 
 func testAccSecurityGroupRule(t *testing.T, fileName, groupName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/security_group_test.go
+++ b/nifcloud/acc/security_group_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -79,7 +79,7 @@ func TestAcc_SecurityGroup(t *testing.T) {
 }
 
 func testAccSecurityGroup(t *testing.T, fileName, groupName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/separate_instance_rule_test.go
+++ b/nifcloud/acc/separate_instance_rule_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -107,7 +107,7 @@ func TestAcc_SeparateInstanceRule_Unique_Id(t *testing.T) {
 }
 
 func testAccSeparateInstanceRule(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/ssl_certificate_test.go
+++ b/nifcloud/acc/ssl_certificate_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -79,7 +79,7 @@ func TestAcc_SSLCertificate(t *testing.T) {
 }
 
 func testAccSSLCertificate(t *testing.T, fileName, certificate, key, ca string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/storage_bucket_test.go
+++ b/nifcloud/acc/storage_bucket_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -69,7 +69,7 @@ func TestAcc_StorageBucket(t *testing.T) {
 }
 
 func testAccStorageBucket(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func testAccStorageBucket(t *testing.T, fileName, rName string) string {
 }
 
 func testAccStorageBucketUpdated(t *testing.T, fileName, rName, policy string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/volume_test.go
+++ b/nifcloud/acc/volume_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -118,7 +118,7 @@ func TestAcc_Volume_Unique_Id(t *testing.T) {
 }
 
 func testAccVolume(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/vpn_connection_test.go
+++ b/nifcloud/acc/vpn_connection_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -123,7 +123,7 @@ func TestAcc_VpnConnection_Id_No_Tunnel(t *testing.T) {
 }
 
 func testAccVpnConnection(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/vpn_gateway_test.go
+++ b/nifcloud/acc/vpn_gateway_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -92,7 +92,7 @@ func TestAcc_VpnGateway(t *testing.T) {
 }
 
 func testAccVpnGateway(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/nifcloud/acc/web_proxy_test.go
+++ b/nifcloud/acc/web_proxy_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -78,7 +78,7 @@ func TestAcc_WebProxy(t *testing.T) {
 }
 
 func testAccWebProxy(t *testing.T, fileName, rName string) string {
-	b, err := ioutil.ReadFile(fileName)
+	b, err := os.ReadFile(fileName)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
Fixed lint errors

- ioutil is deprecated since Go 1.19.
- Some linters are deprecated.

## Tests

- [x] CI passes