### PR TITLE
resource/nifcloud_loadbalancer: Fix filter settings

### DIFF
--- a/nifcloud/resources/network/loadbalancer/expander.go
+++ b/nifcloud/resources/network/loadbalancer/expander.go
@@ -225,10 +225,9 @@ func expandSetFilterForLoadBalancerFilterType(d *schema.ResourceData) *computing
 	}
 }
 
-func expandSetFilterForLoadBalancer(d *schema.ResourceData) *computing.SetFilterForLoadBalancerInput {
+func expandSetFilterForLoadBalancer(d *schema.ResourceData, list []interface{}) *computing.SetFilterForLoadBalancerInput {
 	var filters []types.RequestIPAddresses
-	fl := d.Get("filter").(*schema.Set).List()
-	for _, i := range fl {
+	for _, i := range list {
 		filters = append(filters, types.RequestIPAddresses{
 			IPAddress:   nifcloud.String(i.(string)),
 			AddOnFilter: nifcloud.Bool(true),
@@ -243,11 +242,9 @@ func expandSetFilterForLoadBalancer(d *schema.ResourceData) *computing.SetFilter
 	}
 }
 
-func expandUnSetFilterForLoadBalancer(d *schema.ResourceData) *computing.SetFilterForLoadBalancerInput {
-	o, _ := d.GetChange("filter")
+func expandUnSetFilterForLoadBalancer(d *schema.ResourceData, list []interface{}) *computing.SetFilterForLoadBalancerInput {
 	var filters []types.RequestIPAddresses
-	fl := o.(*schema.Set).List()
-	for _, i := range fl {
+	for _, i := range list {
 		filters = append(filters, types.RequestIPAddresses{
 			IPAddress:   nifcloud.String(i.(string)),
 			AddOnFilter: nifcloud.Bool(false),

--- a/nifcloud/resources/network/loadbalancer/flattener.go
+++ b/nifcloud/resources/network/loadbalancer/flattener.go
@@ -29,14 +29,15 @@ func flatten(d *schema.ResourceData, res *computing.DescribeLoadBalancersOutput)
 	if err := d.Set("instances", instances); err != nil {
 		return err
 	}
-	if d.Get("filter") != nil && len(loadBalancer.Filter.IPAddresses) > 0 && *loadBalancer.Filter.IPAddresses[0].IPAddress != "*.*.*.*" {
-		filters := make([]string, len(loadBalancer.Filter.IPAddresses))
-		for i, filter := range loadBalancer.Filter.IPAddresses {
-			filters[i] = nifcloud.ToString(filter.IPAddress)
+
+	filters := []string{}
+	for _, filter := range loadBalancer.Filter.IPAddresses {
+		if nifcloud.ToString(filter.IPAddress) != "*.*.*.*" {
+			filters = append(filters, nifcloud.ToString(filter.IPAddress))
 		}
-		if err := d.Set("filter", filters); err != nil {
-			return err
-		}
+	}
+	if err := d.Set("filter", filters); err != nil {
+		return err
 	}
 
 	if err := d.Set("filter_type", loadBalancer.Filter.FilterType); err != nil {

--- a/nifcloud/resources/network/loadbalancer/update.go
+++ b/nifcloud/resources/network/loadbalancer/update.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/nifcloud/nifcloud-sdk-go/nifcloud"
 	"github.com/nifcloud/terraform-provider-nifcloud/nifcloud/client"
 )
 
@@ -87,16 +86,25 @@ func update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.
 		}
 	}
 	if d.HasChange("filter") {
-		input := expandUnSetFilterForLoadBalancer(d)
-		if len(input.IPAddresses.Member) > 0 && nifcloud.ToString(input.IPAddresses.Member[0].IPAddress) != "*.*.*.*" {
+		o, n := d.GetChange("filter")
+		os := o.(*schema.Set)
+		ns := n.(*schema.Set)
+
+		addFilters := ns.Difference(os).List()
+		delFilters := os.Difference(ns).List()
+
+		if len(addFilters) > 0 {
+			input := expandSetFilterForLoadBalancer(d, addFilters)
+
 			_, err := svc.SetFilterForLoadBalancer(ctx, input)
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("failed setting load balancer filters %s", err))
 			}
 		}
 
-		input = expandSetFilterForLoadBalancer(d)
-		if len(input.IPAddresses.Member) > 0 && nifcloud.ToString(input.IPAddresses.Member[0].IPAddress) != "*.*.*.*" {
+		if len(delFilters) > 0 {
+			input := expandUnSetFilterForLoadBalancer(d, delFilters)
+
 			_, err := svc.SetFilterForLoadBalancer(ctx, input)
 			if err != nil {
 				return diag.FromErr(fmt.Errorf("failed setting load balancer filters %s", err))

--- a/nifcloud/resources/network/loadbalancerlistener/expander.go
+++ b/nifcloud/resources/network/loadbalancerlistener/expander.go
@@ -204,10 +204,9 @@ func expandSetFilterForLoadBalancerFilterType(d *schema.ResourceData) *computing
 	}
 }
 
-func expandSetFilterForLoadBalancer(d *schema.ResourceData) *computing.SetFilterForLoadBalancerInput {
+func expandSetFilterForLoadBalancer(d *schema.ResourceData, list []interface{}) *computing.SetFilterForLoadBalancerInput {
 	var filters []types.RequestIPAddresses
-	fl := d.Get("filter").(*schema.Set).List()
-	for _, i := range fl {
+	for _, i := range list {
 		filters = append(filters, types.RequestIPAddresses{
 			IPAddress:   nifcloud.String(i.(string)),
 			AddOnFilter: nifcloud.Bool(true),
@@ -222,11 +221,9 @@ func expandSetFilterForLoadBalancer(d *schema.ResourceData) *computing.SetFilter
 	}
 }
 
-func expandUnSetFilterForLoadBalancer(d *schema.ResourceData) *computing.SetFilterForLoadBalancerInput {
-	o, _ := d.GetChange("filter")
+func expandUnSetFilterForLoadBalancer(d *schema.ResourceData, list []interface{}) *computing.SetFilterForLoadBalancerInput {
 	var filters []types.RequestIPAddresses
-	fl := o.(*schema.Set).List()
-	for _, i := range fl {
+	for _, i := range list {
 		filters = append(filters, types.RequestIPAddresses{
 			IPAddress:   nifcloud.String(i.(string)),
 			AddOnFilter: nifcloud.Bool(false),

--- a/nifcloud/resources/network/loadbalancerlistener/flattener.go
+++ b/nifcloud/resources/network/loadbalancerlistener/flattener.go
@@ -29,14 +29,15 @@ func flatten(d *schema.ResourceData, res *computing.DescribeLoadBalancersOutput)
 	if err := d.Set("instances", instances); err != nil {
 		return err
 	}
-	if d.Get("filter") != nil && len(loadBalancer.Filter.IPAddresses) > 0 && *loadBalancer.Filter.IPAddresses[0].IPAddress != "*.*.*.*" {
-		filters := make([]string, len(loadBalancer.Filter.IPAddresses))
-		for i, filter := range loadBalancer.Filter.IPAddresses {
-			filters[i] = nifcloud.ToString(filter.IPAddress)
+
+	filters := []string{}
+	for _, filter := range loadBalancer.Filter.IPAddresses {
+		if nifcloud.ToString(filter.IPAddress) != "*.*.*.*" {
+			filters = append(filters, nifcloud.ToString(filter.IPAddress))
 		}
-		if err := d.Set("filter", filters); err != nil {
-			return err
-		}
+	}
+	if err := d.Set("filter", filters); err != nil {
+		return err
 	}
 
 	if err := d.Set("filter_type", loadBalancer.Filter.FilterType); err != nil {


### PR DESCRIPTION
## Description

- Refactor of nifcloud_loadbalancer resource for fix filter settings

## How Has This Been Tested?

- [ ]   Buld with make install command.
```
make install
```
- [ ]   Apply this example.
```hcl
terraform {
  required_providers {
    nifcloud = {
      source = "nifcloud/nifcloud"
    }
  }
}

provider "nifcloud" {
  region = "jp-east-1"
}

resource "nifcloud_load_balancer" "basic" {
  load_balancer_name = "l4lb"
  instance_port      = 80
  load_balancer_port = 80
  accounting_type    = "1"

  filter = [
      "1.1.1.1",
      "1.1.1.2",
  ]
}

```
- [ ] Run acceptance tests.
```
TF_ACC=1 go test ./nifcloud/acc/... -v -count 1 -parallel 1 -timeout 360m -run TestAcc_LoadBalancer
```
- [ ] Enjoy!!😸 

## Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improves code quality but has no user-facing effect)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation